### PR TITLE
Add home base landmark at world origin

### DIFF
--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -79,6 +79,13 @@ export interface Dropoff extends Entity {
   rewardPerItem: number;
 }
 
+export interface HomeBase {
+  x: number;
+  y: number;
+  /** Radius of the base boundary */
+  radius: number;
+}
+
 export interface Projectile {
   x: number;
   y: number;
@@ -188,5 +195,13 @@ export function createDropoff(x: number, y: number): Dropoff {
     pingedThisWave: false,
     radius: 60,
     rewardPerItem: 50,
+  };
+}
+
+export function createHomeBase(x: number, y: number): HomeBase {
+  return {
+    x,
+    y,
+    radius: 150,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { Player } from './entities/Player';
 import { InputSystem } from './systems/InputSystem';
 import { PingSystem } from './systems/PingSystem';
 import { CombatSystem } from './systems/CombatSystem';
-import { Ally, Enemy, Resource, Dropoff } from './entities/Entity';
+import { Ally, Enemy, Resource, Dropoff, HomeBase, createHomeBase } from './entities/Entity';
 import { UpgradeSystem } from './systems/UpgradeSystem';
 import { World } from './world/World';
 import { HUD } from './ui/HUD';
@@ -60,6 +60,7 @@ let keyRemapScreen: KeyRemapScreen;
 let motionTrail: MotionTrail;
 let towRopeSystem: TowRopeSystem;
 let minimap: Minimap;
+let homeBase: HomeBase;
 let resolutionLevel: number;
 let gameOver: boolean;
 let prevHealth: number;
@@ -80,6 +81,7 @@ function init() {
   gameOverScreen = new GameOverScreen();
   floatingText = new FloatingText();
   screenShake = new ScreenShake();
+  homeBase = createHomeBase(0, 0);
   resolutionLevel = 0;
   gameOver = false;
   prevHealth = player.health;
@@ -437,6 +439,64 @@ const loop = new GameLoop({
     // Motion trails (rendered behind blips)
     motionTrail.render(ctx, player.x, player.y, cx, cy);
 
+    // Home base — boundary ring and center marker
+    {
+      const hbx = homeBase.x - player.x;
+      const hby = homeBase.y - player.y;
+      if (hbx * hbx + hby * hby <= viewRadiusSq) {
+        const hsx = cx + hbx;
+        const hsy = cy + hby;
+        const pulse = 1 + Math.sin(player.survivalTime * 1.5) * 0.05;
+
+        ctx.save();
+
+        // Outer boundary ring
+        ctx.beginPath();
+        ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(100, 220, 255, 0.25)';
+        ctx.lineWidth = 2;
+        ctx.shadowColor = '#64dcff';
+        ctx.shadowBlur = 10;
+        ctx.stroke();
+
+        // Inner glow fill
+        ctx.beginPath();
+        ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(100, 220, 255, 0.03)';
+        ctx.fill();
+
+        // Inner ring (second boundary line for depth)
+        ctx.beginPath();
+        ctx.arc(hsx, hsy, homeBase.radius * 0.6 * pulse, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(100, 220, 255, 0.12)';
+        ctx.lineWidth = 1;
+        ctx.shadowBlur = 0;
+        ctx.stroke();
+
+        // Center structure — hexagon shape
+        ctx.translate(hsx, hsy);
+        const hexRadius = 10;
+        ctx.beginPath();
+        for (let i = 0; i < 6; i++) {
+          const angle = (Math.PI / 3) * i - Math.PI / 6;
+          const hxp = Math.cos(angle) * hexRadius;
+          const hyp = Math.sin(angle) * hexRadius;
+          if (i === 0) ctx.moveTo(hxp, hyp);
+          else ctx.lineTo(hxp, hyp);
+        }
+        ctx.closePath();
+        ctx.fillStyle = 'rgba(100, 220, 255, 0.4)';
+        ctx.strokeStyle = 'rgba(100, 220, 255, 0.7)';
+        ctx.lineWidth = 1.5;
+        ctx.shadowColor = '#64dcff';
+        ctx.shadowBlur = 8;
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.restore();
+      }
+    }
+
     // Dropoff zones — pulsing ring markers
     for (const entity of world.entities) {
       if (!entity.active || entity.type !== 'dropoff') continue;
@@ -647,7 +707,7 @@ const loop = new GameLoop({
     hud.render(ctx, player, canvas.width, canvas.height);
 
     // Minimap (bottom left)
-    minimap.render(ctx, player, world.entities, canvas.width, canvas.height);
+    minimap.render(ctx, player, world.entities, canvas.width, canvas.height, homeBase);
 
     // Ability bar (bottom center)
     abilityBar.render(ctx, abilitySystem.abilities, canvas.width, canvas.height);

--- a/src/ui/Minimap.ts
+++ b/src/ui/Minimap.ts
@@ -1,5 +1,5 @@
 import { Player } from '../entities/Player';
-import { GameEntity } from '../entities/Entity';
+import { GameEntity, HomeBase } from '../entities/Entity';
 
 const SIZE = 160;
 const PADDING = 20;
@@ -70,6 +70,7 @@ export class Minimap {
     entities: GameEntity[],
     canvasWidth: number,
     canvasHeight: number,
+    homeBase?: HomeBase,
   ): void {
     const x = PADDING;
     const y = canvasHeight - PADDING - SIZE;
@@ -92,6 +93,24 @@ export class Minimap {
 
     const centerX = x + SIZE / 2;
     const centerY = y + SIZE / 2;
+
+    // Home base marker
+    if (homeBase) {
+      const basePos = this.worldToMinimap(homeBase.x, homeBase.y, player, canvasWidth, canvasHeight);
+      // Base radius ring
+      const scale = SIZE / 2 / WORLD_RADIUS;
+      const baseRadiusOnMap = homeBase.radius * scale;
+      ctx.beginPath();
+      ctx.arc(basePos.x, basePos.y, Math.max(baseRadiusOnMap, 3), 0, Math.PI * 2);
+      ctx.strokeStyle = 'rgba(100, 220, 255, 0.4)';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+      // Base center dot
+      ctx.beginPath();
+      ctx.arc(basePos.x, basePos.y, 2, 0, Math.PI * 2);
+      ctx.fillStyle = '#64dcff';
+      ctx.fill();
+    }
 
     // Entity dots
     const visible = this.getVisibleEntities(entities);


### PR DESCRIPTION
## Summary

Adds a placeholder home base at `(0, 0)` — the player's spawn point — as groundwork for future base-building mechanics. The base renders as a cyan hexagon with two boundary rings (outer at 150px, inner at 90px) and appears on the minimap so the player can always orient back to it.

## Changes

- **Entity.ts** — new `HomeBase` interface and `createHomeBase()` factory. Kept separate from `GameEntity` since the base doesn't participate in ping/cleanup systems.
- **main.ts** — creates the base at init, renders it in the rotated world layer (before dropoff zones), passes it to the minimap.
- **Minimap.ts** — optional `homeBase` param renders a cyan dot + radius ring on the minimap.

## Test plan

- [x] `npm run build` passes
- [x] All 220 tests pass
- [ ] Visual check: base visible at spawn, disappears when flying far away, reappears on return
- [ ] Minimap shows cyan base marker that moves relative to player

🤖 Generated with [Claude Code](https://claude.com/claude-code)