### PR TITLE
chore: add deploy script for GitHub Pages

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Build the project
+echo "Building..."
+npm run build
+
+# Deploy to gh-pages branch
+echo "Deploying to GitHub Pages..."
+cd dist
+
+git init
+git checkout -b gh-pages
+git add -A
+git commit -m "deploy"
+git push -f git@github.com:jcquinlan/radar-game.git gh-pages:gh-pages
+
+cd -
+echo "Deployed to https://jcquinlan.github.io/radar-game/"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: '/radar-game/',
   server: {
     port: 3232,
   },


### PR DESCRIPTION
## Summary
- Adds `deploy.sh` that builds the project and force-pushes `dist/` to the `gh-pages` branch
- Sets Vite `base: '/radar-game/'` so asset paths resolve correctly on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)