### PR TITLE
feat: home base HP, damage tinting, and salvage deposit

### DIFF
--- a/src/entities/Entity.test.ts
+++ b/src/entities/Entity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createResource, createEnemy, createAlly } from './Entity';
+import { createResource, createEnemy, createAlly, createHomeBase } from './Entity';
 
 describe('Entity factories', () => {
   it('creates a resource at the given position', () => {
@@ -65,6 +65,15 @@ describe('Entity factories', () => {
   it('creates a random ally subtype when none specified', () => {
     const a = createAlly(300, 400);
     expect(['healer', 'shield', 'beacon']).toContain(a.subtype);
+  });
+
+  it('creates a home base with health and maxHealth', () => {
+    const hb = createHomeBase(100, 200);
+    expect(hb.x).toBe(100);
+    expect(hb.y).toBe(200);
+    expect(hb.radius).toBe(150);
+    expect(hb.health).toBe(500);
+    expect(hb.maxHealth).toBe(500);
   });
 
   it('creates enemies with ghost marker and wander fields initialized', () => {

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -84,6 +84,10 @@ export interface HomeBase {
   y: number;
   /** Radius of the base boundary */
   radius: number;
+  /** Current health of the home base */
+  health: number;
+  /** Maximum health of the home base */
+  maxHealth: number;
 }
 
 export interface Projectile {
@@ -203,5 +207,7 @@ export function createHomeBase(x: number, y: number): HomeBase {
     x,
     y,
     radius: 150,
+    health: 500,
+    maxHealth: 500,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -411,6 +411,16 @@ const loop = new GameLoop({
         floatingText.add(`+${dropoff.rewardPerItem}E`, salvage.x, salvage.y, theme.entities.dropoff);
         screenShake.trigger(2);
       }
+      // Home base also acts as a salvage deposit point
+      const homeDeposited = towRopeSystem.checkHomeDeposit(homeBase);
+      for (const salvage of homeDeposited) {
+        const reward = TowRopeSystem.HOME_DEPOSIT_REWARD;
+        player.addEnergy(reward);
+        player.score += reward;
+        player.salvageDeposited++;
+        floatingText.add(`+${reward}E`, salvage.x, salvage.y, theme.entities.dropoff);
+        screenShake.trigger(2);
+      }
     }
 
     // Shield buff countdown
@@ -554,7 +564,7 @@ const loop = new GameLoop({
     // Motion trails (rendered behind blips)
     motionTrail.render(ctx, player.x, player.y, cx, cy);
 
-    // Home base — boundary ring and center marker
+    // Home base — boundary ring and center marker (tints toward red when damaged)
     {
       const hbx = homeBase.x - player.x;
       const hby = homeBase.y - player.y;
@@ -563,27 +573,34 @@ const loop = new GameLoop({
         const hsy = cy + hby;
         const pulse = 1 + Math.sin(player.survivalTime * 1.5) * 0.05;
 
+        // Interpolate color from cyan (100,220,255) to red (255,60,60) based on damage
+        const hpRatio = homeBase.maxHealth > 0 ? homeBase.health / homeBase.maxHealth : 1;
+        const hbR = Math.round(100 + (255 - 100) * (1 - hpRatio));
+        const hbG = Math.round(220 * hpRatio + 60 * (1 - hpRatio));
+        const hbB = Math.round(255 * hpRatio + 60 * (1 - hpRatio));
+        const hbHex = `#${hbR.toString(16).padStart(2, '0')}${hbG.toString(16).padStart(2, '0')}${hbB.toString(16).padStart(2, '0')}`;
+
         ctx.save();
 
         // Outer boundary ring
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.25)';
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.25)`;
         ctx.lineWidth = 2;
-        ctx.shadowColor = '#64dcff';
+        ctx.shadowColor = hbHex;
         ctx.shadowBlur = 10;
         ctx.stroke();
 
         // Inner glow fill
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(100, 220, 255, 0.03)';
+        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.03)`;
         ctx.fill();
 
         // Inner ring (second boundary line for depth)
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * 0.6 * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.12)';
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.12)`;
         ctx.lineWidth = 1;
         ctx.shadowBlur = 0;
         ctx.stroke();
@@ -600,10 +617,10 @@ const loop = new GameLoop({
           else ctx.lineTo(hxp, hyp);
         }
         ctx.closePath();
-        ctx.fillStyle = 'rgba(100, 220, 255, 0.4)';
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.7)';
+        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.4)`;
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.7)`;
         ctx.lineWidth = 1.5;
-        ctx.shadowColor = '#64dcff';
+        ctx.shadowColor = hbHex;
         ctx.shadowBlur = 8;
         ctx.fill();
         ctx.stroke();
@@ -826,7 +843,7 @@ const loop = new GameLoop({
     }
 
     // HUD
-    hud.render(ctx, player, canvas.width, canvas.height);
+    hud.render(ctx, player, canvas.width, canvas.height, homeBase);
 
     // Tutorial hints
     if (currentLevelConfig && currentLevelConfig.hints.length > 0) {

--- a/src/systems/TowRopeSystem.test.ts
+++ b/src/systems/TowRopeSystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createSalvage, createDropoff } from '../entities/Entity';
+import { createSalvage, createDropoff, createHomeBase } from '../entities/Entity';
 import { Player } from '../entities/Player';
 import {
   TowRopeSystem,
@@ -259,6 +259,61 @@ describe('TowRopeSystem', () => {
 
       expect(deposited).toHaveLength(2);
       expect(system.getTowedItems()).toHaveLength(0);
+    });
+  });
+
+  describe('checkHomeDeposit', () => {
+    it('deposits salvage when it enters the home base radius', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(10, 0); // Within 150px radius
+      system.collect(salvage);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(1);
+      expect(deposited[0]).toBe(salvage);
+      expect(system.getTowedItems()).toHaveLength(0);
+      expect(salvage.towedByPlayer).toBe(false);
+      expect(salvage.active).toBe(false);
+    });
+
+    it('does not deposit salvage outside the home base radius', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(200, 0); // Beyond 150px radius
+      system.collect(salvage);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(0);
+      expect(system.getTowedItems()).toHaveLength(1);
+    });
+
+    it('ignores fading salvage', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(10, 0);
+      system.collect(salvage);
+      system.getTowedItems()[0].fadeOut = 0.2;
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(0);
+    });
+
+    it('deposits multiple salvage items at once', () => {
+      const homeBase = createHomeBase(0, 0);
+      const s1 = buildSalvage(10, 0);
+      const s2 = buildSalvage(0, 10);
+      system.collect(s1);
+      system.collect(s2);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(2);
+      expect(system.getTowedItems()).toHaveLength(0);
+    });
+
+    it('has a static HOME_DEPOSIT_REWARD of 50', () => {
+      expect(TowRopeSystem.HOME_DEPOSIT_REWARD).toBe(50);
     });
   });
 

--- a/src/systems/TowRopeSystem.ts
+++ b/src/systems/TowRopeSystem.ts
@@ -1,4 +1,4 @@
-import { Salvage, Dropoff } from '../entities/Entity';
+import { Salvage, Dropoff, HomeBase } from '../entities/Entity';
 import { Player } from '../entities/Player';
 
 // Tuning constants — exported for tests and future adjustment
@@ -169,6 +169,30 @@ export class TowRopeSystem {
           item.salvage.active = false;
           this.items.splice(i, 1);
         }
+      }
+    }
+
+    return deposited;
+  }
+
+  /** Energy reward per salvage item deposited at the home base */
+  static readonly HOME_DEPOSIT_REWARD = 50;
+
+  /** Check if any towed salvage has entered the home base radius. Returns deposited salvage items. */
+  checkHomeDeposit(homeBase: HomeBase): Salvage[] {
+    const deposited: Salvage[] = [];
+
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      const item = this.items[i];
+      if (item.fadeOut !== null) continue; // Already fading
+
+      const dx = item.salvage.x - homeBase.x;
+      const dy = item.salvage.y - homeBase.y;
+      if (dx * dx + dy * dy < homeBase.radius * homeBase.radius) {
+        deposited.push(item.salvage);
+        item.salvage.towedByPlayer = false;
+        item.salvage.active = false;
+        this.items.splice(i, 1);
       }
     }
 

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,4 +1,5 @@
 import { Player } from '../entities/Player';
+import { HomeBase } from '../entities/Entity';
 import { getThreatLevel } from '../world/World';
 import { getTheme } from '../themes/theme';
 
@@ -22,6 +23,7 @@ export class HUD {
     player: Player,
     canvasWidth: number,
     canvasHeight: number,
+    homeBase?: HomeBase,
   ): void {
     const padding = 20;
     const barWidth = 200;
@@ -45,24 +47,48 @@ export class HUD {
       `HP: ${Math.ceil(player.health)}/${player.maxHealth}${player.shieldActive ? ' [SHIELD]' : ''}`
     );
 
+    // Base HP bar (below player HP bar)
+    if (homeBase) {
+      const baseBarY = y + barHeight + 4;
+      const baseRatio = homeBase.health / homeBase.maxHealth;
+      // Interpolate color from cyan to red based on damage
+      const r = Math.round(100 + (255 - 100) * (1 - baseRatio));
+      const g = Math.round(220 * baseRatio + 60 * (1 - baseRatio));
+      const b = Math.round(255 * baseRatio + 60 * (1 - baseRatio));
+      const baseColor = `rgb(${r}, ${g}, ${b})`;
+      this.renderBar(
+        ctx,
+        padding,
+        baseBarY,
+        barWidth,
+        barHeight,
+        baseRatio,
+        baseColor,
+        `BASE: ${Math.ceil(homeBase.health)}/${homeBase.maxHealth}`
+      );
+    }
+
+    // Offset subsequent elements when base bar is present
+    const baseBarOffset = homeBase ? barHeight + 4 : 0;
+
     // Energy counter
     ctx.fillStyle = theme.ui.textPrimary;
     ctx.shadowColor = theme.ui.textPrimary;
     ctx.shadowBlur = 5;
-    ctx.fillText(`Energy: ${Math.floor(player.energy)}`, padding, y + barHeight + 24);
+    ctx.fillText(`Energy: ${Math.floor(player.energy)}`, padding, y + barHeight + baseBarOffset + 24);
     ctx.shadowBlur = 0;
 
     // Distance from origin
     const dist = Math.floor(Math.sqrt(player.x * player.x + player.y * player.y));
     ctx.fillStyle = theme.ui.textSecondary;
-    ctx.fillText(`RANGE: ${dist}m`, padding, y + barHeight + 44);
+    ctx.fillText(`RANGE: ${dist}m`, padding, y + barHeight + baseBarOffset + 44);
 
     // Threat level
     const threat = getThreatLevel(player.x, player.y);
     ctx.fillStyle = threat.color;
     ctx.shadowColor = threat.color;
     ctx.shadowBlur = 3;
-    ctx.fillText(`THREAT: ${threat.label}`, padding, y + barHeight + 64);
+    ctx.fillText(`THREAT: ${threat.label}`, padding, y + barHeight + baseBarOffset + 64);
     ctx.shadowBlur = 0;
 
     // Coordinates
@@ -71,7 +97,7 @@ export class HUD {
     ctx.fillText(
       `POS: ${Math.floor(player.x)}, ${Math.floor(player.y)}`,
       padding,
-      y + barHeight + 82
+      y + barHeight + baseBarOffset + 82
     );
 
     // Score (top right)


### PR DESCRIPTION
## Summary

Extends the HomeBase from a visual-only landmark into a gameplay entity with health, damage tinting, and salvage deposit functionality. The home base now acts as a deposit point for towed salvage (awarding 50 energy per item, same as dropoff zones), displays a health bar on the HUD, and visually tints from cyan toward red as it takes damage.

## Changes

The starting point is the `HomeBase` interface in `Entity.ts`, which previously had only position and radius. This PR adds `health` (500) and `maxHealth` (500) fields, with the factory function updated to include them.

Next, `TowRopeSystem` gains a `checkHomeDeposit(homeBase)` method that mirrors the existing `checkDropoffs()` pattern — it iterates towed items in reverse, checks if any salvage has entered the base radius, and detaches + deactivates matching items. A static `HOME_DEPOSIT_REWARD = 50` constant keeps the reward value co-located with the deposit logic.

In `main.ts`, the home deposit check is called right after the existing dropoff check in the update loop, awarding energy and triggering floating text + screen shake. The home base rendering block now computes an RGB color interpolated from cyan `(100, 220, 255)` to red `(255, 60, 60)` based on the health ratio, replacing the previously hardcoded cyan values.

Finally, `HUD.ts` renders a base HP bar directly below the player HP bar using the existing `renderBar()` helper, with the same cyan-to-red color interpolation. Subsequent HUD elements (energy, range, threat, coordinates) are offset downward to accommodate the new bar.

## PRDs Completed
1. **prd-001** [frontend] — Home base HP, damage tinting, and salvage deposit

## Test Coverage
- 6 new tests: 5 for `checkHomeDeposit` (deposit within radius, reject outside radius, ignore fading, multiple items, reward constant) + 1 for `createHomeBase` factory
- Full suite: 268 tests passing
- TypeScript strict mode: clean
- Production build: clean

## Quality Gates
- [x] Tests pass (268/268)
- [x] TypeScript strict check passes
- [x] Production build succeeds
- [x] Code review: clean diff following existing patterns
- [x] No runtime dependencies added

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2