### PR TITLE
Add defense entity data model: turret + repair station

### DIFF
--- a/src/entities/Entity.test.ts
+++ b/src/entities/Entity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createResource, createEnemy, createAlly } from './Entity';
+import { createResource, createEnemy, createAlly, createTurret, createRepairStation } from './Entity';
 
 describe('Entity factories', () => {
   it('creates a resource at the given position', () => {
@@ -74,5 +74,45 @@ describe('Entity factories', () => {
     expect(e.wanderAngle).toBeGreaterThanOrEqual(0);
     expect(e.wanderAngle).toBeLessThan(Math.PI * 2);
     expect(e.wanderTimer).toBeGreaterThan(0);
+  });
+
+  it('creates a turret at the given position with correct defaults', () => {
+    const t = createTurret(150, 250);
+    expect(t.type).toBe('turret');
+    expect(t.x).toBe(150);
+    expect(t.y).toBe(250);
+    expect(t.health).toBe(50);
+    expect(t.maxHealth).toBe(50);
+    expect(t.range).toBe(200);
+    expect(t.damage).toBe(5);
+    expect(t.fireRate).toBe(1);
+    expect(t.lastFireTime).toBe(0);
+    expect(t.active).toBe(true);
+    expect(t.aimDirection).toBe(0);
+  });
+
+  it('creates a repair station at the given position with correct defaults', () => {
+    const rs = createRepairStation(300, 400);
+    expect(rs.type).toBe('repair_station');
+    expect(rs.x).toBe(300);
+    expect(rs.y).toBe(400);
+    expect(rs.health).toBe(30);
+    expect(rs.maxHealth).toBe(30);
+    expect(rs.healRate).toBe(3);
+    expect(rs.range).toBe(100);
+    expect(rs.active).toBe(true);
+  });
+
+  it('Defense union type discriminates turret from repair station', () => {
+    const turret = createTurret(0, 0);
+    const station = createRepairStation(0, 0);
+
+    // Type narrowing works via the type field
+    if (turret.type === 'turret') {
+      expect(turret.damage).toBe(5);
+    }
+    if (station.type === 'repair_station') {
+      expect(station.healRate).toBe(3);
+    }
   });
 });

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -79,6 +79,40 @@ export interface Dropoff extends Entity {
   rewardPerItem: number;
 }
 
+export interface Turret {
+  type: 'turret';
+  x: number;
+  y: number;
+  health: number;
+  maxHealth: number;
+  /** Detection/firing range in pixels */
+  range: number;
+  /** Damage per shot */
+  damage: number;
+  /** Shots per second */
+  fireRate: number;
+  /** Timestamp of last shot (seconds) */
+  lastFireTime: number;
+  active: boolean;
+  /** Current aim direction in radians (fixed for now — no AI yet) */
+  aimDirection: number;
+}
+
+export interface RepairStation {
+  type: 'repair_station';
+  x: number;
+  y: number;
+  health: number;
+  maxHealth: number;
+  /** HP healed per second to nearby entities */
+  healRate: number;
+  /** Healing range in pixels */
+  range: number;
+  active: boolean;
+}
+
+export type Defense = Turret | RepairStation;
+
 export interface HomeBase {
   x: number;
   y: number;
@@ -195,6 +229,35 @@ export function createDropoff(x: number, y: number): Dropoff {
     pingedThisWave: false,
     radius: 60,
     rewardPerItem: 50,
+  };
+}
+
+export function createTurret(x: number, y: number): Turret {
+  return {
+    type: 'turret',
+    x,
+    y,
+    health: 50,
+    maxHealth: 50,
+    range: 200,
+    damage: 5,
+    fireRate: 1,
+    lastFireTime: 0,
+    active: true,
+    aimDirection: 0,
+  };
+}
+
+export function createRepairStation(x: number, y: number): RepairStation {
+  return {
+    type: 'repair_station',
+    x,
+    y,
+    health: 30,
+    maxHealth: 30,
+    healRate: 3,
+    range: 100,
+    active: true,
   };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { Player } from './entities/Player';
 import { InputSystem } from './systems/InputSystem';
 import { PingSystem } from './systems/PingSystem';
 import { CombatSystem } from './systems/CombatSystem';
-import { Ally, Enemy, Resource, Dropoff, HomeBase, createHomeBase } from './entities/Entity';
+import { Ally, Enemy, Resource, Dropoff, HomeBase, Defense, createHomeBase } from './entities/Entity';
 import { UpgradeSystem } from './systems/UpgradeSystem';
 import { World } from './world/World';
 import { HUD } from './ui/HUD';
@@ -71,6 +71,7 @@ let motionTrail: MotionTrail;
 let towRopeSystem: TowRopeSystem;
 let minimap: Minimap;
 let homeBase: HomeBase;
+let defenses: Defense[] = [];
 let resolutionLevel: number;
 let prevHealth: number;
 let damageFlash: number;
@@ -107,6 +108,7 @@ function init() {
   floatingText = new FloatingText();
   screenShake = new ScreenShake();
   homeBase = createHomeBase(0, 0);
+  defenses = [];
   resolutionLevel = 0;
   prevHealth = player.health;
   damageFlash = 0;
@@ -609,6 +611,39 @@ const loop = new GameLoop({
         ctx.stroke();
 
         ctx.restore();
+      }
+    }
+
+    // Defense entities — turrets and repair stations
+    for (const def of defenses) {
+      if (!def.active) continue;
+      const ddx = def.x - player.x;
+      const ddy = def.y - player.y;
+      if (ddx * ddx + ddy * ddy > viewRadiusSq) continue;
+      const dsx = cx + ddx;
+      const dsy = cy + ddy;
+
+      if (def.type === 'turret') {
+        // Cyan square (6x6) with aim-direction line
+        ctx.fillStyle = '#00ddff';
+        ctx.fillRect(dsx - 3, dsy - 3, 6, 6);
+        // Aim direction line (8px long)
+        ctx.beginPath();
+        ctx.moveTo(dsx, dsy);
+        ctx.lineTo(dsx + Math.cos(def.aimDirection) * 8, dsy + Math.sin(def.aimDirection) * 8);
+        ctx.strokeStyle = '#00ddff';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      } else {
+        // Repair station: green cross/plus with pulsing glow
+        const pulseAlpha = 0.5 + Math.sin(player.survivalTime * 3) * 0.3;
+        ctx.globalAlpha = pulseAlpha;
+        ctx.fillStyle = '#00ff41';
+        // Horizontal bar of cross
+        ctx.fillRect(dsx - 6, dsy - 1.5, 12, 3);
+        // Vertical bar of cross
+        ctx.fillRect(dsx - 1.5, dsy - 6, 3, 12);
+        ctx.globalAlpha = 1;
       }
     }
 


### PR DESCRIPTION
## Summary

Adds Turret and RepairStation as new defense entity types with interfaces, factory functions, a `Defense` union type, and rendering code in the rotated world layer. This is data-model-and-rendering groundwork for Phase 2 of the GDD (base defense loop) — no behavior or AI yet, just the structural foundation that future PRs will build on.

## Changes

The change walks through three files in a natural progression:

**`src/entities/Entity.ts`** — Defines `Turret` and `RepairStation` interfaces as standalone types (not part of `GameEntity`, matching the pattern used by `HomeBase` and `Projectile`). Both use a `type` discriminator field (`'turret'` | `'repair_station'`) for the `Defense` union type. Factory functions `createTurret(x, y)` and `createRepairStation(x, y)` follow the exact same pattern as `createResource`, `createEnemy`, etc.

**`src/main.ts`** — Adds a `defenses: Defense[]` array at module scope, cleared on `init()`. Rendering code in the rotated world layer draws turrets as 6x6 cyan squares with an 8px aim-direction line, and repair stations as green cross/plus symbols with a pulsing alpha oscillation (no `shadowBlur` — follows the perf rules). Both use squared-distance culling against `viewRadiusSq`.

**`src/entities/Entity.test.ts`** — Three new behavioral tests: turret factory defaults, repair station factory defaults, and Defense union type discrimination.

## Decisions Made

| # | Question | Decision | Rationale |
|---|----------|----------|-----------|
| 1 | Should Defense be part of GameEntity? | No | Ticket specifies this; follows HomeBase/Projectile pattern |
| 2 | Where to render defenses? | Between home base and dropoff zones | Natural z-order for world objects |
| 3 | Repair station glow effect? | Alpha oscillation, no shadowBlur | Performance rules forbid shadowBlur in hot loops |
| 4 | Turret aim direction? | Fixed at 0 radians | No AI yet per spec |

## PRDs Completed

1. **prd-001** [frontend] — Defense entity data model, factories, and rendering

## Test Coverage

- 3 new tests for factory functions and type discrimination
- Full suite: 265 tests passing
- TypeScript strict mode: clean

## Quality Gates

- [x] Tests pass (265/265)
- [x] TypeScript strict mode compiles clean
- [x] No shadowBlur in render path
- [x] No allocations in hot loop
- [x] Distance culling for off-screen defenses

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2