### PR TITLE
feat: GDD timed run + base defense game loop (Phases 1-3)

### DIFF
--- a/src/entities/Entity.test.ts
+++ b/src/entities/Entity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createResource, createEnemy, createAlly } from './Entity';
+import { createResource, createEnemy, createAlly, createHomeBase, createTurret, createRepairStation } from './Entity';
 
 describe('Entity factories', () => {
   it('creates a resource at the given position', () => {
@@ -67,6 +67,22 @@ describe('Entity factories', () => {
     expect(['healer', 'shield', 'beacon']).toContain(a.subtype);
   });
 
+  it('creates a home base with health and maxHealth', () => {
+    const hb = createHomeBase(100, 200);
+    expect(hb.x).toBe(100);
+    expect(hb.y).toBe(200);
+    expect(hb.radius).toBe(150);
+    expect(hb.health).toBe(500);
+    expect(hb.maxHealth).toBe(500);
+  });
+
+  it('creates enemies with waveEnemy and isBoss defaulting to false', () => {
+    const e = createEnemy(50, 75, 'scout');
+    expect(e.waveEnemy).toBe(false);
+    expect(e.isBoss).toBe(false);
+  });
+
+
   it('creates enemies with ghost marker and wander fields initialized', () => {
     const e = createEnemy(50, 75, 'scout');
     expect(e.ghostX).toBeNull();
@@ -74,5 +90,45 @@ describe('Entity factories', () => {
     expect(e.wanderAngle).toBeGreaterThanOrEqual(0);
     expect(e.wanderAngle).toBeLessThan(Math.PI * 2);
     expect(e.wanderTimer).toBeGreaterThan(0);
+  });
+
+  it('creates a turret at the given position with correct defaults', () => {
+    const t = createTurret(150, 250);
+    expect(t.type).toBe('turret');
+    expect(t.x).toBe(150);
+    expect(t.y).toBe(250);
+    expect(t.health).toBe(50);
+    expect(t.maxHealth).toBe(50);
+    expect(t.range).toBe(200);
+    expect(t.damage).toBe(5);
+    expect(t.fireRate).toBe(1);
+    expect(t.lastFireTime).toBe(0);
+    expect(t.active).toBe(true);
+    expect(t.aimDirection).toBe(0);
+  });
+
+  it('creates a repair station at the given position with correct defaults', () => {
+    const rs = createRepairStation(300, 400);
+    expect(rs.type).toBe('repair_station');
+    expect(rs.x).toBe(300);
+    expect(rs.y).toBe(400);
+    expect(rs.health).toBe(30);
+    expect(rs.maxHealth).toBe(30);
+    expect(rs.healRate).toBe(3);
+    expect(rs.range).toBe(100);
+    expect(rs.active).toBe(true);
+  });
+
+  it('Defense union type discriminates turret from repair station', () => {
+    const turret = createTurret(0, 0);
+    const station = createRepairStation(0, 0);
+
+    // Type narrowing works via the type field
+    if (turret.type === 'turret') {
+      expect(turret.damage).toBe(5);
+    }
+    if (station.type === 'repair_station') {
+      expect(station.healRate).toBe(3);
+    }
   });
 });

--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -42,6 +42,10 @@ export interface Enemy extends Entity {
   wanderAngle: number;
   /** Time until next wander direction change */
   wanderTimer: number;
+  /** Whether this enemy is part of a final wave (not a world-spawned enemy) */
+  waveEnemy: boolean;
+  /** Whether this enemy is a wave boss (renders larger) */
+  isBoss: boolean;
 }
 
 export type AllySubtype = 'healer' | 'shield' | 'beacon';
@@ -79,11 +83,49 @@ export interface Dropoff extends Entity {
   rewardPerItem: number;
 }
 
+export interface Turret {
+  type: 'turret';
+  x: number;
+  y: number;
+  health: number;
+  maxHealth: number;
+  /** Detection/firing range in pixels */
+  range: number;
+  /** Damage per shot */
+  damage: number;
+  /** Shots per second */
+  fireRate: number;
+  /** Timestamp of last shot (seconds) */
+  lastFireTime: number;
+  active: boolean;
+  /** Current aim direction in radians (fixed for now — no AI yet) */
+  aimDirection: number;
+}
+
+export interface RepairStation {
+  type: 'repair_station';
+  x: number;
+  y: number;
+  health: number;
+  maxHealth: number;
+  /** HP healed per second to nearby entities */
+  healRate: number;
+  /** Healing range in pixels */
+  range: number;
+  active: boolean;
+}
+
+export type Defense = Turret | RepairStation;
+
 export interface HomeBase {
   x: number;
   y: number;
   /** Radius of the base boundary */
   radius: number;
+  /** Current health of the home base */
+  health: number;
+  /** Maximum health of the home base */
+  maxHealth: number;
 }
 
 export interface Projectile {
@@ -143,6 +185,8 @@ export function createEnemy(x: number, y: number, subtype?: EnemySubtype): Enemy
     ghostY: null,
     wanderAngle: Math.random() * Math.PI * 2,
     wanderTimer: 1 + Math.random() * 2,
+    waveEnemy: false,
+    isBoss: false,
   };
 }
 
@@ -198,10 +242,41 @@ export function createDropoff(x: number, y: number): Dropoff {
   };
 }
 
+export function createTurret(x: number, y: number): Turret {
+  return {
+    type: 'turret',
+    x,
+    y,
+    health: 50,
+    maxHealth: 50,
+    range: 200,
+    damage: 5,
+    fireRate: 1,
+    lastFireTime: 0,
+    active: true,
+    aimDirection: 0,
+  };
+}
+
+export function createRepairStation(x: number, y: number): RepairStation {
+  return {
+    type: 'repair_station',
+    x,
+    y,
+    health: 30,
+    maxHealth: 30,
+    healRate: 3,
+    range: 100,
+    active: true,
+  };
+}
+
 export function createHomeBase(x: number, y: number): HomeBase {
   return {
     x,
     y,
     radius: 150,
+    health: 500,
+    maxHealth: 500,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,9 @@ import { Player } from './entities/Player';
 import { InputSystem } from './systems/InputSystem';
 import { PingSystem } from './systems/PingSystem';
 import { CombatSystem } from './systems/CombatSystem';
-import { Ally, Enemy, Resource, Dropoff, HomeBase, createHomeBase } from './entities/Entity';
+import { Ally, Enemy, GameEntity, Resource, Dropoff, HomeBase, Defense, createHomeBase } from './entities/Entity';
+import { spawnWave } from './systems/WaveSpawner';
+import { tryPlaceDefense, TURRET_COST, REPAIR_STATION_COST } from './systems/DefensePlacement';
 import { UpgradeSystem } from './systems/UpgradeSystem';
 import { World } from './world/World';
 import { HUD } from './ui/HUD';
@@ -33,6 +35,8 @@ import { LevelManager } from './levels/LevelManager';
 import { LevelConfig, checkAllObjectivesComplete, getObjectiveProgress } from './levels/LevelConfig';
 import { MainMenuScreen } from './ui/MainMenuScreen';
 import { LevelCompleteScreen } from './ui/LevelCompleteScreen';
+import { ResultsScreen } from './ui/ResultsScreen';
+import { calculateCurrency, calculateReducedCurrency, loadSaveData, saveSaveData, SaveData } from './systems/SaveSystem';
 
 type GameState = 'menu' | 'playing' | 'level_complete' | 'base_mode' | 'run_active' | 'final_wave' | 'results' | 'game_over' | 'paused';
 
@@ -49,7 +53,10 @@ const helpScreen = new HelpScreen();
 const levelManager = new LevelManager();
 const mainMenuScreen = new MainMenuScreen();
 const levelCompleteScreen = new LevelCompleteScreen();
+const resultsScreen = new ResultsScreen();
 let gameState: GameState = 'menu';
+/** Persistent save data loaded from localStorage */
+let saveData: SaveData = loadSaveData();
 /** Tracks the state before pausing so we can restore it on unpause */
 let previousState: GameState = 'menu';
 
@@ -77,12 +84,21 @@ let deathParticles: DeathParticles;
 let towRopeSystem: TowRopeSystem;
 let minimap: Minimap;
 let homeBase: HomeBase;
+let defenses: Defense[] = [];
+/** Maximum number of defenses the player can place (upgradeable later) */
+let maxDefenses = 3;
 let resolutionLevel: number;
 let prevHealth: number;
 let damageFlash: number;
+/** Countdown timer for timed runs (seconds). -1 means no active timer. */
+let runTimer: number = -1;
+/** Current run number (1-based). Controls wave size and difficulty scaling. */
+let runCount: number = 1;
 let currentLevelConfig: LevelConfig | null = null;
 /** Pre-allocated Set for motion trail pruning — reused every frame to avoid GC pressure */
 const activeTrailIds = new Set<string>();
+/** Pre-allocated target position object — reused every frame to avoid GC pressure */
+const waveTargetPos = { x: 0, y: 0 };
 /** Bounds for the START RUN button in base_mode (recalculated each render) */
 let startRunBounds: { x: number; y: number; width: number; height: number } | null = null;
 /** Click handler for base_mode START RUN button */
@@ -142,6 +158,7 @@ function startRun() {
   keyRemapScreen.attach(canvas, abilitySystem.abilities);
   upgradePanel.attach(canvas, upgradeSystem, player);
   world.updateSpawning(player.x, player.y);
+  runTimer = 600; // 10 minutes
   gameState = 'run_active';
 }
 
@@ -185,6 +202,7 @@ function init() {
   floatingText = new FloatingText();
   screenShake = new ScreenShake();
   homeBase = createHomeBase(0, 0);
+  defenses = [];
   resolutionLevel = 0;
   prevHealth = player.health;
   damageFlash = 0;
@@ -239,6 +257,50 @@ function init() {
   world.updateSpawning(player.x, player.y);
 }
 
+/** Show results screen after a successful run (wave survived) */
+function showRunResults() {
+  const baseHpPercent = homeBase.maxHealth > 0 ? homeBase.health / homeBase.maxHealth : 0;
+  const currency = calculateCurrency(player.salvageDeposited, player.kills, baseHpPercent);
+  saveData.currency += currency;
+  saveData.runCount++;
+  saveSaveData(saveData);
+
+  gameState = 'results';
+  towRopeSystem.clear();
+  deathParticles.reset();
+  resultsScreen.show(canvas, {
+    salvageDeposited: player.salvageDeposited,
+    enemiesKilled: player.kills,
+    baseHpPercent,
+    currencyEarned: currency,
+  }, () => {
+    cleanupCurrentGame();
+    enterBaseMode();
+  });
+}
+
+/** Show results screen after a failed run (player died or base destroyed) */
+function showRunFailed() {
+  const baseHpPercent = homeBase.maxHealth > 0 ? homeBase.health / homeBase.maxHealth : 0;
+  const currency = calculateReducedCurrency(player.salvageDeposited, player.kills, baseHpPercent);
+  saveData.currency += currency;
+  saveData.runCount++;
+  saveSaveData(saveData);
+
+  gameState = 'game_over';
+  towRopeSystem.clear();
+  deathParticles.reset();
+  resultsScreen.show(canvas, {
+    salvageDeposited: player.salvageDeposited,
+    enemiesKilled: player.kills,
+    baseHpPercent,
+    currencyEarned: currency,
+  }, () => {
+    cleanupCurrentGame();
+    enterBaseMode();
+  }, true);
+}
+
 function cleanupCurrentGame() {
   if (input) input.detach();
   if (upgradePanel) upgradePanel.detach(canvas);
@@ -246,6 +308,7 @@ function cleanupCurrentGame() {
   if (towRopeSystem) towRopeSystem.clear();
   if (deathParticles) deathParticles.reset();
   if (gameOverScreen) gameOverScreen.hide(canvas);
+  if (resultsScreen) resultsScreen.hide(canvas);
   if (levelCompleteScreen) levelCompleteScreen.hide(canvas);
   leaveBaseMode();
 }
@@ -331,12 +394,40 @@ window.addEventListener('wheel', (e) => {
 
 // Toggle panels (registered once, outside init)
 window.addEventListener('keydown', (e) => {
-  // Escape toggles pause from any active gameplay state or base_mode
+  // Escape closes help screen first, then toggles pause
   if (e.key === 'Escape') {
+    if (helpScreen.isVisible()) {
+      helpScreen.toggle();
+      return;
+    }
     if (gameState === 'paused' || isActiveGameplay(gameState) || gameState === 'base_mode') {
       togglePause();
       return;
     }
+  }
+
+  // Defense placement — T/R keys during run_active or base_mode, near home base
+  if ((gameState === 'run_active' || gameState === 'base_mode') && (e.key === 't' || e.key === 'T')) {
+    const result = tryPlaceDefense('turret', player.energy, defenses, maxDefenses, homeBase.radius, player.x, player.y);
+    if (result.success) {
+      player.energy -= result.cost;
+      defenses.push(result.defense);
+      floatingText.add('TURRET PLACED', result.defense.x, result.defense.y - 15, '#00ddff');
+    } else {
+      floatingText.add(result.reason, player.x, player.y - 15, '#ff6666');
+    }
+    return;
+  }
+  if ((gameState === 'run_active' || gameState === 'base_mode') && (e.key === 'r' || e.key === 'R')) {
+    const result = tryPlaceDefense('repair_station', player.energy, defenses, maxDefenses, homeBase.radius, player.x, player.y);
+    if (result.success) {
+      player.energy -= result.cost;
+      defenses.push(result.defense);
+      floatingText.add('REPAIR STATION PLACED', result.defense.x, result.defense.y - 15, '#00ff41');
+    } else {
+      floatingText.add(result.reason, player.x, player.y - 15, '#ff6666');
+    }
+    return;
   }
 
   // Only handle remaining keys during active gameplay or pause
@@ -360,7 +451,7 @@ window.addEventListener('keydown', (e) => {
   if ((e.key === 'k' || e.key === 'K') && isActiveGameplay(gameState)) {
     keyRemapScreen.toggle();
   }
-  if ((e.key === 'h' || e.key === 'H') && gameState === 'playing') {
+  if ((e.key === 'h' || e.key === 'H') && (isActiveGameplay(gameState) || gameState === 'base_mode')) {
     helpScreen.toggle();
     return;
   }
@@ -417,6 +508,48 @@ showMainMenu();
 const loop = new GameLoop({
   update(dt) {
     if (!isActiveGameplay(gameState)) return;
+
+    // Run timer countdown — only during timed runs
+    if (gameState === 'run_active' && runTimer >= 0) {
+      runTimer -= dt;
+      if (runTimer <= 0) {
+        runTimer = 0;
+
+        // Auto-deposit towed salvage before clearing entities
+        const towedItems = towRopeSystem.getTowedItems();
+        for (const item of towedItems) {
+          player.addEnergy(50);
+          player.score += 50;
+          player.salvageDeposited++;
+        }
+        towRopeSystem.clear();
+
+        // Teleport player to home base position
+        player.x = 0;
+        player.y = 0;
+        player.vx = 0;
+        player.vy = 0;
+
+        // Close upgrade panel if open
+        if (upgradePanel.isVisible()) {
+          upgradePanel.toggle();
+        }
+
+        // Spawn the final wave and transition to final_wave state
+        const waveEnemies = spawnWave(runCount);
+        // Clear non-wave entities from the world before adding wave enemies
+        world.entities.length = 0;
+        for (const enemy of waveEnemies) {
+          world.entities.push(enemy);
+        }
+        gameState = 'final_wave';
+
+        // Show WAVE INCOMING floating text
+        floatingText.add('WAVE INCOMING', 0, -30, '#ffff00');
+
+        return;
+      }
+    }
 
     const features = currentLevelConfig?.features;
 
@@ -514,6 +647,16 @@ const loop = new GameLoop({
         floatingText.add(`+${dropoff.rewardPerItem}E`, salvage.x, salvage.y, theme.entities.dropoff);
         screenShake.trigger(2);
       }
+      // Home base also acts as a salvage deposit point
+      const homeDeposited = towRopeSystem.checkHomeDeposit(homeBase);
+      for (const salvage of homeDeposited) {
+        const reward = TowRopeSystem.HOME_DEPOSIT_REWARD;
+        player.addEnergy(reward);
+        player.score += reward;
+        player.salvageDeposited++;
+        floatingText.add(`+${reward}E`, salvage.x, salvage.y, theme.entities.dropoff);
+        screenShake.trigger(2);
+      }
     }
 
     // Shield buff countdown
@@ -548,19 +691,47 @@ const loop = new GameLoop({
       abilityEffects.update(dt);
     }
 
+    // Turret AI — fire at nearby enemies
+    if (features?.combat !== false && defenses.length > 0) {
+      combatSystem.updateTurrets(defenses, world.entities, player.survivalTime, dt);
+    }
+
     // Combat — only if enabled
     let alive = true;
     if (features?.combat !== false) {
+      // During final_wave, enemies target the home base instead of the player
+      let targetPos: { x: number; y: number } | undefined;
+      let baseTarget: HomeBase | undefined;
+      if (gameState === 'final_wave') {
+        waveTargetPos.x = homeBase.x;
+        waveTargetPos.y = homeBase.y;
+        targetPos = waveTargetPos;
+        baseTarget = homeBase;
+      }
       alive = combatSystem.update(
         world.entities, player, dt, abilitySystem.isDashing(), 15,
         (text, x, y, color) => floatingText.add(text, x, y, color),
         (x, y, srcX, srcY, color) => deathParticles.emitFromSource(x, y, srcX, srcY, color),
         (x, y, srcX, srcY, color) => deathParticles.emitFromSource(x, y, srcX, srcY, color, 5),
+        targetPos,
+        baseTarget,
+        defenses.length > 0 ? defenses : undefined,
       );
     }
 
     // Death particles
     deathParticles.update(dt);
+
+    // Repair station healing — heal player when within range
+    for (let i = 0; i < defenses.length; i++) {
+      const def = defenses[i];
+      if (!def.active || def.type !== 'repair_station') continue;
+      const rdx = player.x - def.x;
+      const rdy = player.y - def.y;
+      if (rdx * rdx + rdy * rdy < def.range * def.range) {
+        player.heal(def.healRate * dt);
+      }
+    }
 
     // Motion trails — track fast-moving entities
     motionTrail.track('player', player.x, player.y, player.vx, player.vy, theme.radar.primary, dt);
@@ -581,6 +752,13 @@ const loop = new GameLoop({
         const pid = `p${i}`;
         motionTrail.track(pid, p.x, p.y, p.vx, p.vy, theme.effects.projectile, dt);
         activeTrailIds.add(pid);
+      }
+      for (let i = 0; i < combatSystem.turretProjectiles.length; i++) {
+        const tp = combatSystem.turretProjectiles[i];
+        if (!tp.active) continue;
+        const tpid = `tp${i}`;
+        motionTrail.track(tpid, tp.x, tp.y, tp.vx, tp.vy, '#00ddff', dt);
+        activeTrailIds.add(tpid);
       }
     }
     if (features?.abilities !== false) {
@@ -618,17 +796,44 @@ const loop = new GameLoop({
     }
 
     if (!alive) {
-      gameState = 'game_over';
-      towRopeSystem.clear();
-      deathParticles.reset();
-      gameOverScreen.show(canvas, player, () => {
-        cleanupCurrentGame();
-        showMainMenu();
-      });
+      if (gameState === 'run_active' || gameState === 'final_wave') {
+        showRunFailed();
+      } else {
+        gameState = 'game_over';
+        towRopeSystem.clear();
+        deathParticles.reset();
+        gameOverScreen.show(canvas, player, () => {
+          cleanupCurrentGame();
+          showMainMenu();
+        });
+      }
+      return;
     }
 
-    // Periodic cleanup
-    world.cleanup(player.x, player.y);
+    // Wave end conditions during final_wave
+    if (gameState === 'final_wave') {
+      // Base destroyed — run failed
+      if (homeBase.health <= 0) {
+        homeBase.health = 0;
+        showRunFailed();
+        return;
+      }
+
+      // All wave enemies dead — wave survived, show results
+      const waveEnemiesAlive = world.entities.some(
+        (e: GameEntity) => e.active && e.type === 'enemy' && (e as Enemy).waveEnemy
+      );
+      if (!waveEnemiesAlive) {
+        runCount++;
+        showRunResults();
+        return;
+      }
+    }
+
+    // Periodic cleanup — preserve wave enemies during final_wave
+    if (gameState !== 'final_wave') {
+      world.cleanup(player.x, player.y);
+    }
   },
   render() {
     // Main menu render
@@ -728,6 +933,56 @@ const loop = new GameLoop({
       ctx.fillStyle = '#00ff41';
       ctx.textAlign = 'center';
       ctx.fillText('START RUN', bcx, btnY + 32);
+
+      // Currency display
+      ctx.font = '16px monospace';
+      ctx.fillStyle = '#ffaa00';
+      ctx.textAlign = 'center';
+      ctx.fillText(`CURRENCY: ${saveData.currency}`, bcx, bcy + 170);
+
+      // Run count
+      if (saveData.runCount > 0) {
+        ctx.font = '12px monospace';
+        ctx.fillStyle = 'rgba(136, 170, 136, 0.6)';
+        ctx.fillText(`Runs completed: ${saveData.runCount}`, bcx, bcy + 190);
+      }
+
+      // Defense placement hint in base mode
+      if (defenses.length < maxDefenses && player.energy >= 75) {
+        ctx.font = '13px monospace';
+        ctx.textAlign = 'center';
+        ctx.fillStyle = 'rgba(170, 220, 170, 0.85)';
+        const hintY = canvas.height - 35;
+        ctx.fillText('[T] Turret (100)  |  [R] Repair (75)', bcx, hintY);
+        ctx.font = '10px monospace';
+        ctx.fillStyle = 'rgba(136, 170, 136, 0.6)';
+        ctx.fillText(`Defenses: ${defenses.length}/${maxDefenses}`, bcx, hintY + 14);
+      }
+
+      // Render existing defenses in base mode
+      for (const def of defenses) {
+        if (!def.active) continue;
+        const dsx = bcx + def.x;
+        const dsy = bcy + def.y;
+        if (def.type === 'turret') {
+          ctx.fillStyle = '#00ddff';
+          ctx.fillRect(dsx - 3, dsy - 3, 6, 6);
+          ctx.beginPath();
+          ctx.moveTo(dsx, dsy);
+          ctx.lineTo(dsx + Math.cos(def.aimDirection) * 8, dsy + Math.sin(def.aimDirection) * 8);
+          ctx.strokeStyle = '#00ddff';
+          ctx.lineWidth = 1.5;
+          ctx.stroke();
+        } else {
+          const pulseAlpha = 0.5 + Math.sin(performance.now() / 333) * 0.3;
+          ctx.globalAlpha = pulseAlpha;
+          ctx.fillStyle = '#00ff41';
+          ctx.fillRect(dsx - 6, dsy - 1.5, 12, 3);
+          ctx.fillRect(dsx - 1.5, dsy - 6, 3, 12);
+          ctx.globalAlpha = 1;
+        }
+      }
+
       ctx.restore();
 
       // Pause menu (if paused from base_mode — shows on top)
@@ -766,7 +1021,7 @@ const loop = new GameLoop({
     // Motion trails (rendered behind blips)
     motionTrail.render(ctx, player.x, player.y, cx, cy);
 
-    // Home base — boundary ring and center marker
+    // Home base — boundary ring and center marker (tints toward red when damaged)
     {
       const hbx = homeBase.x - player.x;
       const hby = homeBase.y - player.y;
@@ -775,27 +1030,34 @@ const loop = new GameLoop({
         const hsy = cy + hby;
         const pulse = 1 + Math.sin(player.survivalTime * 1.5) * 0.05;
 
+        // Interpolate color from cyan (100,220,255) to red (255,60,60) based on damage
+        const hpRatio = homeBase.maxHealth > 0 ? homeBase.health / homeBase.maxHealth : 1;
+        const hbR = Math.round(100 + (255 - 100) * (1 - hpRatio));
+        const hbG = Math.round(220 * hpRatio + 60 * (1 - hpRatio));
+        const hbB = Math.round(255 * hpRatio + 60 * (1 - hpRatio));
+        const hbHex = `#${hbR.toString(16).padStart(2, '0')}${hbG.toString(16).padStart(2, '0')}${hbB.toString(16).padStart(2, '0')}`;
+
         ctx.save();
 
         // Outer boundary ring
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.25)';
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.25)`;
         ctx.lineWidth = 2;
-        ctx.shadowColor = '#64dcff';
+        ctx.shadowColor = hbHex;
         ctx.shadowBlur = 10;
         ctx.stroke();
 
         // Inner glow fill
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(100, 220, 255, 0.03)';
+        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.03)`;
         ctx.fill();
 
         // Inner ring (second boundary line for depth)
         ctx.beginPath();
         ctx.arc(hsx, hsy, homeBase.radius * 0.6 * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.12)';
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.12)`;
         ctx.lineWidth = 1;
         ctx.shadowBlur = 0;
         ctx.stroke();
@@ -812,15 +1074,48 @@ const loop = new GameLoop({
           else ctx.lineTo(hxp, hyp);
         }
         ctx.closePath();
-        ctx.fillStyle = 'rgba(100, 220, 255, 0.4)';
-        ctx.strokeStyle = 'rgba(100, 220, 255, 0.7)';
+        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.4)`;
+        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.7)`;
         ctx.lineWidth = 1.5;
-        ctx.shadowColor = '#64dcff';
+        ctx.shadowColor = hbHex;
         ctx.shadowBlur = 8;
         ctx.fill();
         ctx.stroke();
 
         ctx.restore();
+      }
+    }
+
+    // Defense entities — turrets and repair stations
+    for (const def of defenses) {
+      if (!def.active) continue;
+      const ddx = def.x - player.x;
+      const ddy = def.y - player.y;
+      if (ddx * ddx + ddy * ddy > viewRadiusSq) continue;
+      const dsx = cx + ddx;
+      const dsy = cy + ddy;
+
+      if (def.type === 'turret') {
+        // Cyan square (6x6) with aim-direction line
+        ctx.fillStyle = '#00ddff';
+        ctx.fillRect(dsx - 3, dsy - 3, 6, 6);
+        // Aim direction line (8px long)
+        ctx.beginPath();
+        ctx.moveTo(dsx, dsy);
+        ctx.lineTo(dsx + Math.cos(def.aimDirection) * 8, dsy + Math.sin(def.aimDirection) * 8);
+        ctx.strokeStyle = '#00ddff';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      } else {
+        // Repair station: green cross/plus with pulsing glow
+        const pulseAlpha = 0.5 + Math.sin(player.survivalTime * 3) * 0.3;
+        ctx.globalAlpha = pulseAlpha;
+        ctx.fillStyle = '#00ff41';
+        // Horizontal bar of cross
+        ctx.fillRect(dsx - 6, dsy - 1.5, 12, 3);
+        // Vertical bar of cross
+        ctx.fillRect(dsx - 1.5, dsy - 6, 3, 12);
+        ctx.globalAlpha = 1;
       }
     }
 
@@ -955,6 +1250,23 @@ const loop = new GameLoop({
       ctx.restore();
     }
 
+    // Render turret projectiles (cyan)
+    for (const p of combatSystem.turretProjectiles) {
+      const trx = p.x - player.x;
+      const try_ = p.y - player.y;
+      if (trx * trx + try_ * try_ > viewRadiusSq) continue;
+      const tpx = cx + trx;
+      const tpy = cy + try_;
+      ctx.save();
+      ctx.shadowColor = '#00ddff';
+      ctx.shadowBlur = 6;
+      ctx.beginPath();
+      ctx.arc(tpx, tpy, 2, 0, Math.PI * 2);
+      ctx.fillStyle = '#00ddff';
+      ctx.fill();
+      ctx.restore();
+    }
+
     // Render drones
     for (const drone of abilitySystem.drones) {
       const drx = drone.x - player.x;
@@ -1041,7 +1353,10 @@ const loop = new GameLoop({
     }
 
     // HUD
-    hud.render(ctx, player, canvas.width, canvas.height);
+    const nearBase = gameState === 'run_active'
+      && player.x * player.x + player.y * player.y < homeBase.radius * homeBase.radius;
+    hud.render(ctx, player, canvas.width, canvas.height, runTimer, homeBase,
+      { show: nearBase, defenseCount: defenses.length, maxDefenses });
 
     // Tutorial hints
     if (currentLevelConfig && currentLevelConfig.hints.length > 0) {
@@ -1085,6 +1400,9 @@ const loop = new GameLoop({
 
     // Game over overlay
     gameOverScreen.render(ctx, canvas.width, canvas.height);
+
+    // Results screen overlay (win or lose from run mode)
+    resultsScreen.render(ctx, canvas.width, canvas.height);
 
     // Level complete overlay
     levelCompleteScreen.render(ctx, canvas.width, canvas.height);

--- a/src/radar/BlipRenderer.ts
+++ b/src/radar/BlipRenderer.ts
@@ -90,6 +90,10 @@ export class BlipRenderer {
           currentSize = 4;
           color = enemyRangedColor;
         }
+        // Bosses render at 1.5x size
+        if (enemy.isBoss) {
+          currentSize *= 1.5;
+        }
       }
 
       // Ally gentle pulsing aura

--- a/src/systems/CombatSystem.test.ts
+++ b/src/systems/CombatSystem.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CombatSystem } from './CombatSystem';
 import { Player } from '../entities/Player';
-import { createEnemy } from '../entities/Entity';
+import { createEnemy, createHomeBase, createTurret, createRepairStation, Defense } from '../entities/Entity';
 
 describe('CombatSystem', () => {
   let combat: CombatSystem;
@@ -234,5 +234,361 @@ describe('CombatSystem', () => {
 
     // Enemy should be chasing (moving toward player), not wandering away
     expect(enemy.x).toBeLessThan(initialX); // moved toward player at x=250
+  });
+
+  describe('targetPos override', () => {
+    it('enemies chase targetPos instead of player when provided', () => {
+      const enemy = createEnemy(100, 0, 'scout');
+      // Target is at 200, 0 — enemy should move toward it, away from player at 0,0
+      const initialX = enemy.x;
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, { x: 200, y: 0 });
+      expect(enemy.x).toBeGreaterThan(initialX);
+    });
+
+    it('ranged enemies fire at targetPos, not player', () => {
+      // Place ranged enemy between player and target
+      const enemy = createEnemy(100, 0, 'ranged');
+      enemy.fireRate = 0;
+      // Target is at 200, 0
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, { x: 200, y: 0 });
+      // Projectile should move toward x=200 (positive vx)
+      expect(combat.projectiles.length).toBeGreaterThan(0);
+      expect(combat.projectiles[0].vx).toBeGreaterThan(0);
+    });
+
+    it('enemies still deal contact damage to player even when targeting base', () => {
+      const enemy = createEnemy(5, 0, 'scout');
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, { x: 200, y: 0 });
+      expect(player.health).toBeLessThan(player.maxHealth);
+    });
+
+    it('wave enemies always chase regardless of distance to target', () => {
+      // Wave enemy at 2000px from target — beyond normal chaseRange
+      const enemy = createEnemy(2000, 0, 'scout');
+      enemy.waveEnemy = true;
+      enemy.chaseRange = 200; // normal range is tiny
+      const initialX = enemy.x;
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, { x: 0, y: 0 });
+      // Should still chase toward target at origin
+      expect(enemy.x).toBeLessThan(initialX);
+    });
+  });
+
+  describe('base damage', () => {
+    it('wave enemies deal contact damage to base when within 30px', () => {
+      const homeBase = createHomeBase(0, 0);
+      const enemy = createEnemy(10, 0, 'brute');
+      enemy.waveEnemy = true;
+      enemy.damage = 12;
+      const initialHP = homeBase.health;
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, homeBase);
+
+      expect(homeBase.health).toBeLessThan(initialHP);
+    });
+
+    it('non-wave enemies do not damage the base', () => {
+      const homeBase = createHomeBase(0, 0);
+      const enemy = createEnemy(10, 0, 'brute');
+      enemy.waveEnemy = false;
+      const initialHP = homeBase.health;
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, homeBase);
+
+      expect(homeBase.health).toBe(initialHP);
+    });
+
+    it('wave enemies outside 30px do not damage the base', () => {
+      const homeBase = createHomeBase(0, 0);
+      const enemy = createEnemy(50, 0, 'scout');
+      enemy.waveEnemy = true;
+      const initialHP = homeBase.health;
+
+      combat.update([enemy], player, 0.016, false, 15, () => {}, () => {}, () => {}, undefined, homeBase);
+
+      expect(homeBase.health).toBe(initialHP);
+    });
+
+    it('base damage is proportional to enemy damage and dt', () => {
+      const homeBase = createHomeBase(0, 0);
+      const enemy = createEnemy(10, 0, 'brute');
+      enemy.waveEnemy = true;
+      enemy.damage = 20;
+
+      combat.update([enemy], player, 0.5, false, 15, () => {}, () => {}, () => {}, undefined, homeBase);
+
+      // Damage = 20 * 0.5 = 10
+      expect(homeBase.health).toBe(490);
+    });
+  });
+
+  describe('turret AI', () => {
+    it('turret fires projectile at nearest enemy within range', () => {
+      const turret = createTurret(0, 0);
+      turret.lastFireTime = -10; // ensure cooldown has elapsed
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.active = true;
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(1);
+      expect(combat.turretProjectiles[0].vx).toBeGreaterThan(0); // aimed toward enemy at x=100
+    });
+
+    it('turret does not fire when no enemies in range', () => {
+      const turret = createTurret(0, 0);
+      turret.range = 200;
+      const enemy = createEnemy(500, 0, 'scout');
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(0);
+    });
+
+    it('turret respects fire rate cooldown', () => {
+      const turret = createTurret(0, 0);
+      turret.fireRate = 1; // 1 shot per second
+      turret.lastFireTime = 0.5;
+      const enemy = createEnemy(100, 0, 'scout');
+
+      // gameTime=0.8, lastFireTime=0.5 — only 0.3s elapsed, need 1s
+      combat.updateTurrets([turret], [enemy], 0.8, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(0);
+    });
+
+    it('turret fires when cooldown has elapsed', () => {
+      const turret = createTurret(0, 0);
+      turret.fireRate = 1;
+      turret.lastFireTime = 0;
+      const enemy = createEnemy(100, 0, 'scout');
+
+      // gameTime=1.5, lastFireTime=0 — 1.5s elapsed, need 1s
+      combat.updateTurrets([turret], [enemy], 1.5, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(1);
+      expect(turret.lastFireTime).toBe(1.5);
+    });
+
+    it('inactive turret does not fire', () => {
+      const turret = createTurret(0, 0);
+      turret.active = false;
+      turret.lastFireTime = -10;
+      const enemy = createEnemy(100, 0, 'scout');
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(0);
+    });
+
+    it('turret targets nearest enemy when multiple in range', () => {
+      const turret = createTurret(0, 0);
+      turret.lastFireTime = -10;
+      const farEnemy = createEnemy(150, 0, 'scout');
+      const nearEnemy = createEnemy(50, 0, 'scout');
+
+      combat.updateTurrets([turret], [farEnemy, nearEnemy], 1, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(1);
+      // Projectile should be aimed at the nearer enemy
+      expect(combat.turretProjectiles[0].damage).toBe(turret.damage);
+    });
+
+    it('turret updates aimDirection toward target', () => {
+      const turret = createTurret(0, 0);
+      turret.lastFireTime = -10;
+      const enemy = createEnemy(0, 100, 'scout'); // directly below
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      // aimDirection should be ~PI/2 (pointing down/toward y=100)
+      expect(turret.aimDirection).toBeCloseTo(Math.PI / 2, 1);
+    });
+
+    it('turret projectiles have correct speed and damage', () => {
+      const turret = createTurret(0, 0);
+      turret.lastFireTime = -10;
+      turret.damage = 7;
+      const enemy = createEnemy(100, 0, 'scout');
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      const proj = combat.turretProjectiles[0];
+      expect(proj.damage).toBe(7);
+      // Speed should be ~150 px/s
+      const speed = Math.sqrt(proj.vx * proj.vx + proj.vy * proj.vy);
+      expect(speed).toBeCloseTo(150, 0);
+    });
+
+    it('turret ignores inactive enemies', () => {
+      const turret = createTurret(0, 0);
+      turret.lastFireTime = -10;
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.active = false;
+
+      combat.updateTurrets([turret], [enemy], 1, 0.1);
+
+      expect(combat.turretProjectiles.length).toBe(0);
+    });
+  });
+
+  describe('turret projectile vs enemy collision', () => {
+    it('turret projectile damages enemy on contact', () => {
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.health = 15;
+      // Place turret projectile right next to enemy
+      combat.turretProjectiles.push({
+        x: 100, y: 0,
+        vx: 0, vy: 0,
+        damage: 5,
+        active: true,
+        lifetime: 3,
+      });
+
+      combat.update([enemy], player, 0.016);
+
+      expect(enemy.health).toBe(10); // 15 - 5
+      expect(combat.turretProjectiles.length).toBe(0); // consumed
+    });
+
+    it('turret projectile kills enemy and awards score', () => {
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.health = 3;
+      enemy.energyDrop = 10;
+      combat.turretProjectiles.push({
+        x: 100, y: 0,
+        vx: 0, vy: 0,
+        damage: 5,
+        active: true,
+        lifetime: 3,
+      });
+
+      combat.update([enemy], player, 0.016);
+
+      expect(enemy.active).toBe(false);
+      expect(player.kills).toBe(1);
+      expect(player.score).toBe(50);
+      expect(player.energy).toBe(10);
+    });
+
+    it('turret projectiles expire after lifetime', () => {
+      combat.turretProjectiles.push({
+        x: 500, y: 500,
+        vx: 10, vy: 0,
+        damage: 5,
+        active: true,
+        lifetime: 0.1,
+      });
+
+      combat.update([], player, 0.2);
+
+      expect(combat.turretProjectiles.length).toBe(0);
+    });
+
+    it('turret projectiles do not damage the player', () => {
+      combat.turretProjectiles.push({
+        x: 5, y: 0,
+        vx: -100, vy: 0,
+        damage: 15,
+        active: true,
+        lifetime: 3,
+      });
+
+      combat.update([], player, 0.1);
+
+      expect(player.health).toBe(player.maxHealth);
+    });
+  });
+
+  describe('enemy damage to defenses', () => {
+    it('enemy within 30px damages defense health', () => {
+      const turret = createTurret(100, 0);
+      turret.health = 50;
+      const enemy = createEnemy(110, 0, 'scout');
+      enemy.damage = 10;
+      const defenses: Defense[] = [turret];
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(turret.health).toBeLessThan(50);
+    });
+
+    it('enemy outside 30px does not damage defense', () => {
+      const turret = createTurret(100, 0);
+      const enemy = createEnemy(200, 0, 'scout');
+      enemy.damage = 10;
+      const defenses: Defense[] = [turret];
+
+      combat.update([enemy], player, 0.1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(turret.health).toBe(50);
+    });
+
+    it('defense becomes inactive when health reaches 0', () => {
+      const turret = createTurret(100, 0);
+      turret.health = 5;
+      const enemy = createEnemy(105, 0, 'brute');
+      enemy.damage = 20;
+      const defenses: Defense[] = [turret];
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(turret.active).toBe(false);
+      expect(turret.health).toBeLessThanOrEqual(0);
+    });
+
+    it('inactive defenses are not damaged further', () => {
+      const turret = createTurret(100, 0);
+      turret.active = false;
+      turret.health = 0;
+      const enemy = createEnemy(105, 0, 'brute');
+      enemy.damage = 20;
+      const defenses: Defense[] = [turret];
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(turret.health).toBe(0); // not further reduced
+    });
+
+    it('repair stations can be damaged by enemies', () => {
+      const station = createRepairStation(100, 0);
+      station.health = 30;
+      const enemy = createEnemy(105, 0, 'scout');
+      enemy.damage = 6;
+      const defenses: Defense[] = [station];
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(station.health).toBeLessThan(30);
+    });
+
+    it('ranged enemies also damage defenses on contact', () => {
+      const turret = createTurret(100, 0);
+      turret.health = 50;
+      const enemy = createEnemy(105, 0, 'ranged');
+      // ranged enemies have damage=0 normally, but they still have a damage field
+      enemy.damage = 5;
+      const defenses: Defense[] = [turret];
+
+      combat.update([enemy], player, 1, false, 15, () => {}, () => {}, () => {}, undefined, undefined, defenses);
+
+      expect(turret.health).toBeLessThan(50);
+    });
+  });
+
+  describe('repair station healing', () => {
+    // Note: repair station healing is handled in main.ts, not CombatSystem.
+    // These tests verify the Player.heal() method works correctly for this use case.
+    it('player heal method heals by the given amount', () => {
+      player.takeDamage(20);
+      expect(player.health).toBe(80);
+      player.heal(10);
+      expect(player.health).toBe(90);
+    });
+
+    it('player heal does not exceed maxHealth', () => {
+      player.heal(50);
+      expect(player.health).toBe(player.maxHealth);
+    });
   });
 });

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -1,19 +1,91 @@
-import { Enemy, GameEntity, Projectile } from '../entities/Entity';
+import { Defense, Enemy, GameEntity, HomeBase, Projectile } from '../entities/Entity';
 import { Player } from '../entities/Player';
 import { getTheme } from '../themes/theme';
 import type { DeathCallback } from './AbilitySystem';
 
 type FloatingTextCallback = (text: string, x: number, y: number, color: string) => void;
 
+/** Turret projectile speed in pixels per second */
+const TURRET_PROJECTILE_SPEED = 150;
+/** Turret projectile lifetime in seconds */
+const TURRET_PROJECTILE_LIFETIME = 3;
+
 export class CombatSystem {
   projectiles: Projectile[] = [];
+  turretProjectiles: Projectile[] = [];
   private gameTime = 0;
   private ramHitEnemies: Set<Enemy> = new Set();
   private wasRamActive = false;
 
   /**
+   * Update turret AI: find nearest enemy in range, fire projectiles at fire rate.
+   * Updates turret.aimDirection toward the current target.
+   */
+  updateTurrets(
+    defenses: Defense[],
+    entities: GameEntity[],
+    gameTime: number,
+    dt: number,
+  ): void {
+    for (let i = 0; i < defenses.length; i++) {
+      const def = defenses[i];
+      if (!def.active || def.type !== 'turret') continue;
+
+      // Find nearest active enemy within range
+      let nearestEnemy: Enemy | null = null;
+      let nearestDistSq = def.range * def.range;
+
+      for (let j = 0; j < entities.length; j++) {
+        const entity = entities[j];
+        if (!entity.active || entity.type !== 'enemy') continue;
+        const edx = entity.x - def.x;
+        const edy = entity.y - def.y;
+        const distSq = edx * edx + edy * edy;
+        if (distSq < nearestDistSq) {
+          nearestDistSq = distSq;
+          nearestEnemy = entity as Enemy;
+        }
+      }
+
+      if (!nearestEnemy) continue;
+
+      // Update aim direction toward target
+      def.aimDirection = Math.atan2(nearestEnemy.y - def.y, nearestEnemy.x - def.x);
+
+      // Check fire rate cooldown
+      const timeSinceLastFire = gameTime - def.lastFireTime;
+      if (timeSinceLastFire < 1 / def.fireRate) continue;
+
+      // Fire projectile
+      def.lastFireTime = gameTime;
+      const dist = Math.sqrt(nearestDistSq);
+      if (dist === 0) continue;
+      const dirX = (nearestEnemy.x - def.x) / dist;
+      const dirY = (nearestEnemy.y - def.y) / dist;
+
+      this.turretProjectiles.push({
+        x: def.x,
+        y: def.y,
+        vx: dirX * TURRET_PROJECTILE_SPEED,
+        vy: dirY * TURRET_PROJECTILE_SPEED,
+        damage: def.damage,
+        active: true,
+        lifetime: TURRET_PROJECTILE_LIFETIME,
+      });
+    }
+  }
+
+  /**
    * Update enemy AI, projectiles, and handle contact damage.
    * Returns true if the player is still alive.
+   *
+   * @param targetPos - Optional override for enemy AI target position. When provided,
+   *   enemies chase this point instead of the player. Used during final_wave to direct
+   *   enemies toward the home base.
+   * @param baseTarget - Optional home base reference. When provided, enemies within 30px
+   *   of the base deal contactDamage * dt to it.
+   * @param defenses - Optional defense array. When provided, enemies within 30px of an
+   *   active defense deal contactDamage * dt to its health.
    */
   update(
     entities: GameEntity[],
@@ -24,8 +96,15 @@ export class CombatSystem {
     addFloatingText: FloatingTextCallback = () => {},
     onDeath: DeathCallback = () => {},
     onImpact: DeathCallback = () => {},
+    targetPos?: { x: number; y: number },
+    baseTarget?: HomeBase,
+    defenses?: Defense[],
   ): boolean {
     this.gameTime += dt;
+
+    // AI target: use override if provided, otherwise chase the player
+    const aiTargetX = targetPos ? targetPos.x : player.x;
+    const aiTargetY = targetPos ? targetPos.y : player.y;
 
     // Clear ram hit tracking when a new dash starts
     if (ramActive && !this.wasRamActive) {
@@ -37,39 +116,47 @@ export class CombatSystem {
       if (!entity.active || entity.type !== 'enemy') continue;
 
       const enemy = entity as Enemy;
+
+      // Distance to AI target (for chase/fire behavior)
+      const tdx = aiTargetX - enemy.x;
+      const tdy = aiTargetY - enemy.y;
+      const targetDistSq = tdx * tdx + tdy * tdy;
+
+      // Distance to player (for contact damage — always relevant)
       const dx = player.x - enemy.x;
       const dy = player.y - enemy.y;
       const distSq = dx * dx + dy * dy;
 
-      // Chase the player if within range (scouts and brutes)
-      // Stop at standoff distance instead of stacking on top of the player
+      // Chase the AI target if within range (scouts and brutes)
+      // Stop at standoff distance instead of stacking on top of the target
       const standoffDist = enemy.subtype === 'brute' ? 20 : 25;
       const enemyAccel = enemy.speed * enemy.friction;
-      const inChaseRange = distSq < enemy.chaseRange * enemy.chaseRange;
+      // Wave enemies always chase (infinite range); normal enemies use chaseRange
+      const inChaseRange = enemy.waveEnemy || targetDistSq < enemy.chaseRange * enemy.chaseRange;
 
-      if (enemy.subtype !== 'ranged' && inChaseRange && distSq > standoffDist * standoffDist) {
-        const dist = Math.sqrt(distSq);
-        enemy.vx += (dx / dist) * enemyAccel * dt;
-        enemy.vy += (dy / dist) * enemyAccel * dt;
+      if (enemy.subtype !== 'ranged' && inChaseRange && targetDistSq > standoffDist * standoffDist) {
+        const dist = Math.sqrt(targetDistSq);
+        enemy.vx += (tdx / dist) * enemyAccel * dt;
+        enemy.vy += (tdy / dist) * enemyAccel * dt;
       }
 
-      // Ranged enemies: maintain distance and fire
+      // Ranged enemies: maintain distance and fire at AI target
       if (enemy.subtype === 'ranged' && inChaseRange) {
-        const dist = Math.sqrt(distSq);
+        const dist = Math.sqrt(targetDistSq);
         // Back away if too close
         if (dist < 100 && dist > 0) {
-          enemy.vx -= (dx / dist) * enemyAccel * dt;
-          enemy.vy -= (dy / dist) * enemyAccel * dt;
+          enemy.vx -= (tdx / dist) * enemyAccel * dt;
+          enemy.vy -= (tdy / dist) * enemyAccel * dt;
         }
 
-        // Fire projectile
+        // Fire projectile toward AI target
         if (this.gameTime - enemy.lastFireTime >= enemy.fireRate && dist > 0) {
           enemy.lastFireTime = this.gameTime;
           this.projectiles.push({
             x: enemy.x,
             y: enemy.y,
-            vx: (dx / dist) * enemy.projectileSpeed,
-            vy: (dy / dist) * enemy.projectileSpeed,
+            vx: (tdx / dist) * enemy.projectileSpeed,
+            vy: (tdy / dist) * enemy.projectileSpeed,
             damage: 8,
             active: true,
             lifetime: 3,
@@ -136,6 +223,31 @@ export class CombatSystem {
           player.takeDamage(enemy.damage * dt);
         }
       }
+
+      // Base damage: wave enemies within 30px of the base deal contact damage to it
+      if (baseTarget && enemy.waveEnemy) {
+        const baseDx = baseTarget.x - enemy.x;
+        const baseDy = baseTarget.y - enemy.y;
+        if (baseDx * baseDx + baseDy * baseDy < 30 * 30) {
+          baseTarget.health -= enemy.damage * dt;
+        }
+      }
+
+      // Defense damage: enemies within 30px of an active defense deal contact damage
+      if (defenses) {
+        for (let di = 0; di < defenses.length; di++) {
+          const def = defenses[di];
+          if (!def.active) continue;
+          const defDx = def.x - enemy.x;
+          const defDy = def.y - enemy.y;
+          if (defDx * defDx + defDy * defDy < 30 * 30) {
+            def.health -= enemy.damage * dt;
+            if (def.health <= 0) {
+              def.active = false;
+            }
+          }
+        }
+      }
     }
 
     // Update projectiles
@@ -162,6 +274,52 @@ export class CombatSystem {
         player.takeDamage(p.damage);
         onImpact(player.x, player.y, p.x, p.y, getTheme().effects.projectile);
         this.projectiles.splice(i, 1);
+      }
+    }
+
+    // Update turret projectiles — move, expire, check collision with enemies
+    for (let i = this.turretProjectiles.length - 1; i >= 0; i--) {
+      const p = this.turretProjectiles[i];
+      if (!p.active) {
+        this.turretProjectiles.splice(i, 1);
+        continue;
+      }
+
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
+      p.lifetime -= dt;
+
+      if (p.lifetime <= 0) {
+        this.turretProjectiles.splice(i, 1);
+        continue;
+      }
+
+      // Check collision with enemies
+      let hit = false;
+      for (let j = 0; j < entities.length; j++) {
+        const entity = entities[j];
+        if (!entity.active || entity.type !== 'enemy') continue;
+        const enemy = entity as Enemy;
+        const edx = p.x - enemy.x;
+        const edy = p.y - enemy.y;
+        if (edx * edx + edy * edy < 20 * 20) {
+          enemy.health -= p.damage;
+          addFloatingText(`-${p.damage}`, enemy.x, enemy.y, '#00ddff');
+          if (enemy.health <= 0 && enemy.active) {
+            enemy.active = false;
+            const deathColor = enemy.subtype === 'ranged' ? getTheme().entities.enemyRanged : getTheme().entities.enemy;
+            onDeath(enemy.x, enemy.y, p.x, p.y, deathColor);
+            player.addEnergy(enemy.energyDrop);
+            player.kills++;
+            player.score += 50;
+            addFloatingText('+50', enemy.x, enemy.y - 15, getTheme().entities.salvage);
+          }
+          hit = true;
+          break;
+        }
+      }
+      if (hit) {
+        this.turretProjectiles.splice(i, 1);
       }
     }
 

--- a/src/systems/DefensePlacement.test.ts
+++ b/src/systems/DefensePlacement.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { createTurret, createRepairStation } from '../entities/Entity';
+import {
+  isValidDefensePosition,
+  tryPlaceDefense,
+  TURRET_COST,
+  REPAIR_STATION_COST,
+} from './DefensePlacement';
+
+describe('DefensePlacement', () => {
+  describe('isValidDefensePosition', () => {
+    it('accepts a position within base radius with no existing defenses', () => {
+      expect(isValidDefensePosition(10, 10, 150, [])).toBe(true);
+    });
+
+    it('rejects a position outside base radius', () => {
+      expect(isValidDefensePosition(200, 0, 150, [])).toBe(false);
+    });
+
+    it('rejects a position too close to an existing defense', () => {
+      const existing = [createTurret(50, 50)];
+      // 10px away — less than 30px minimum
+      expect(isValidDefensePosition(55, 55, 150, existing)).toBe(false);
+    });
+
+    it('accepts a position far enough from existing defenses', () => {
+      const existing = [createTurret(50, 50)];
+      // ~42px away (diagonal) — more than 30px minimum
+      expect(isValidDefensePosition(80, 80, 150, existing)).toBe(true);
+    });
+
+    it('checks distance against all existing defenses', () => {
+      const existing = [createTurret(50, 0), createRepairStation(-50, 0)];
+      // Close to the second defense
+      expect(isValidDefensePosition(-45, 5, 150, existing)).toBe(false);
+    });
+  });
+
+  describe('tryPlaceDefense', () => {
+    it('fails when player is outside base radius', () => {
+      const result = tryPlaceDefense('turret', 200, [], 3, 150, 300, 0);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('Too far from base');
+      }
+    });
+
+    it('fails when max defenses reached', () => {
+      const defenses = [createTurret(0, 0), createTurret(50, 0), createRepairStation(-50, 0)];
+      const result = tryPlaceDefense('turret', 200, defenses, 3, 150, 10, 10);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('Max defenses reached');
+      }
+    });
+
+    it('fails when player lacks energy for turret', () => {
+      const result = tryPlaceDefense('turret', 50, [], 3, 150, 10, 10);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('Not enough energy');
+      }
+    });
+
+    it('fails when player lacks energy for repair station', () => {
+      const result = tryPlaceDefense('repair_station', 50, [], 3, 150, 10, 10);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.reason).toBe('Not enough energy');
+      }
+    });
+
+    it('places a turret successfully with enough energy and space', () => {
+      const result = tryPlaceDefense('turret', 200, [], 3, 150, 10, 10);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.defense.type).toBe('turret');
+        expect(result.cost).toBe(TURRET_COST);
+        // Position should be within base radius
+        const { x, y } = result.defense;
+        expect(x * x + y * y).toBeLessThanOrEqual(150 * 150);
+      }
+    });
+
+    it('places a repair station successfully', () => {
+      const result = tryPlaceDefense('repair_station', 200, [], 3, 150, 10, 10);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.defense.type).toBe('repair_station');
+        expect(result.cost).toBe(REPAIR_STATION_COST);
+      }
+    });
+
+    it('turret costs 100 energy', () => {
+      expect(TURRET_COST).toBe(100);
+    });
+
+    it('repair station costs 75 energy', () => {
+      expect(REPAIR_STATION_COST).toBe(75);
+    });
+
+    it('placed defense is not overlapping existing defenses', () => {
+      const existing = [createTurret(0, 0)];
+      const result = tryPlaceDefense('turret', 200, existing, 3, 150, 10, 10);
+      if (result.success) {
+        const dx = result.defense.x - existing[0].x;
+        const dy = result.defense.y - existing[0].y;
+        expect(dx * dx + dy * dy).toBeGreaterThanOrEqual(30 * 30);
+      }
+    });
+  });
+});

--- a/src/systems/DefensePlacement.ts
+++ b/src/systems/DefensePlacement.ts
@@ -1,0 +1,100 @@
+import { Defense, createTurret, createRepairStation } from '../entities/Entity';
+
+export const TURRET_COST = 100;
+export const REPAIR_STATION_COST = 75;
+const MIN_DEFENSE_SPACING = 30;
+const MAX_POSITION_ATTEMPTS = 20;
+
+export type PlacementResult =
+  | { success: true; defense: Defense; cost: number }
+  | { success: false; reason: string };
+
+/**
+ * Check if a position is valid for placing a defense:
+ * - Must be within baseRadius of base center (0,0)
+ * - Must be at least MIN_DEFENSE_SPACING from all existing defenses
+ */
+export function isValidDefensePosition(
+  x: number,
+  y: number,
+  baseRadius: number,
+  defenses: Defense[],
+): boolean {
+  // Must be within base radius
+  if (x * x + y * y > baseRadius * baseRadius) return false;
+
+  // Must be at least 30px from any existing defense
+  for (let i = 0; i < defenses.length; i++) {
+    const d = defenses[i];
+    const dx = x - d.x;
+    const dy = y - d.y;
+    if (dx * dx + dy * dy < MIN_DEFENSE_SPACING * MIN_DEFENSE_SPACING) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Find a random valid position within the base radius.
+ * Tries up to MAX_POSITION_ATTEMPTS times with random angle + distance.
+ * Returns null if no valid position found.
+ */
+export function findValidPosition(
+  baseRadius: number,
+  defenses: Defense[],
+): { x: number; y: number } | null {
+  for (let i = 0; i < MAX_POSITION_ATTEMPTS; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    // Use sqrt for uniform distribution within circle
+    const dist = Math.sqrt(Math.random()) * (baseRadius - 10);
+    const x = Math.cos(angle) * dist;
+    const y = Math.sin(angle) * dist;
+    if (isValidDefensePosition(x, y, baseRadius, defenses)) {
+      return { x, y };
+    }
+  }
+  return null;
+}
+
+/**
+ * Attempt to place a defense (turret or repair station).
+ * Returns the result with the created defense or failure reason.
+ */
+export function tryPlaceDefense(
+  type: 'turret' | 'repair_station',
+  playerEnergy: number,
+  defenses: Defense[],
+  maxDefenses: number,
+  baseRadius: number,
+  playerX: number,
+  playerY: number,
+): PlacementResult {
+  // Check if player is within base radius
+  if (playerX * playerX + playerY * playerY > baseRadius * baseRadius) {
+    return { success: false, reason: 'Too far from base' };
+  }
+
+  // Check max defenses
+  if (defenses.length >= maxDefenses) {
+    return { success: false, reason: 'Max defenses reached' };
+  }
+
+  // Check energy
+  const cost = type === 'turret' ? TURRET_COST : REPAIR_STATION_COST;
+  if (playerEnergy < cost) {
+    return { success: false, reason: 'Not enough energy' };
+  }
+
+  // Find valid position
+  const pos = findValidPosition(baseRadius, defenses);
+  if (!pos) {
+    return { success: false, reason: 'No valid position found' };
+  }
+
+  // Create the defense
+  const defense = type === 'turret'
+    ? createTurret(pos.x, pos.y)
+    : createRepairStation(pos.x, pos.y);
+
+  return { success: true, defense, cost };
+}

--- a/src/systems/SaveSystem.test.ts
+++ b/src/systems/SaveSystem.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { calculateCurrency, calculateReducedCurrency, loadSaveData, saveSaveData, SaveData } from './SaveSystem';
+
+describe('calculateCurrency', () => {
+  it('returns correct currency per formula: (salvage*50) + (kills*10) + floor(baseHpPercent*50)', () => {
+    // 3 salvage * 50 = 150, 5 kills * 10 = 50, 80% base HP = floor(0.8*50) = 40
+    expect(calculateCurrency(3, 5, 0.8)).toBe(240);
+  });
+
+  it('returns 0 when all inputs are 0', () => {
+    expect(calculateCurrency(0, 0, 0)).toBe(0);
+  });
+
+  it('handles 100% base HP', () => {
+    expect(calculateCurrency(0, 0, 1.0)).toBe(50);
+  });
+
+  it('floors the base HP contribution', () => {
+    // 33% base HP: floor(0.33 * 50) = floor(16.5) = 16
+    expect(calculateCurrency(0, 0, 0.33)).toBe(16);
+  });
+
+  it('handles large values', () => {
+    // 10 salvage * 50 = 500, 20 kills * 10 = 200, 100% = 50
+    expect(calculateCurrency(10, 20, 1.0)).toBe(750);
+  });
+});
+
+describe('calculateReducedCurrency', () => {
+  it('returns 25% of normal currency (floored)', () => {
+    // Normal would be 240, reduced = floor(240 * 0.25) = 60
+    expect(calculateReducedCurrency(3, 5, 0.8)).toBe(60);
+  });
+
+  it('returns 0 when all inputs are 0', () => {
+    expect(calculateReducedCurrency(0, 0, 0)).toBe(0);
+  });
+
+  it('floors the result', () => {
+    // Normal = 50 (just base HP at 100%), reduced = floor(50 * 0.25) = floor(12.5) = 12
+    expect(calculateReducedCurrency(0, 0, 1.0)).toBe(12);
+  });
+});
+
+describe('loadSaveData', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns default save data when nothing is stored', () => {
+    const data = loadSaveData();
+    expect(data.currency).toBe(0);
+    expect(data.runCount).toBe(0);
+    expect(data.baseUpgrades).toEqual({});
+  });
+
+  it('loads saved data from localStorage', () => {
+    const saved: SaveData = { currency: 500, runCount: 3, baseUpgrades: { armor: 2 } };
+    localStorage.setItem('radar-game-save', JSON.stringify(saved));
+    const data = loadSaveData();
+    expect(data.currency).toBe(500);
+    expect(data.runCount).toBe(3);
+    expect(data.baseUpgrades).toEqual({ armor: 2 });
+  });
+
+  it('returns default when localStorage has invalid JSON', () => {
+    localStorage.setItem('radar-game-save', 'not-json');
+    const data = loadSaveData();
+    expect(data.currency).toBe(0);
+    expect(data.runCount).toBe(0);
+  });
+});
+
+describe('saveSaveData', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves data to localStorage', () => {
+    const data: SaveData = { currency: 100, runCount: 1, baseUpgrades: {} };
+    saveSaveData(data);
+    const raw = localStorage.getItem('radar-game-save');
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toEqual(data);
+  });
+
+  it('overwrites previous save', () => {
+    saveSaveData({ currency: 50, runCount: 1, baseUpgrades: {} });
+    saveSaveData({ currency: 200, runCount: 2, baseUpgrades: { speed: 1 } });
+    const raw = localStorage.getItem('radar-game-save');
+    const parsed = JSON.parse(raw!);
+    expect(parsed.currency).toBe(200);
+    expect(parsed.runCount).toBe(2);
+  });
+});

--- a/src/systems/SaveSystem.ts
+++ b/src/systems/SaveSystem.ts
@@ -1,0 +1,46 @@
+const SAVE_KEY = 'radar-game-save';
+
+export interface SaveData {
+  currency: number;
+  runCount: number;
+  baseUpgrades: Record<string, number>;
+}
+
+const DEFAULT_SAVE: SaveData = {
+  currency: 0,
+  runCount: 0,
+  baseUpgrades: {},
+};
+
+/**
+ * Currency formula: (salvageDeposited * 50) + (enemiesKilled * 10) + floor(baseHpPercent * 50)
+ */
+export function calculateCurrency(salvageDeposited: number, enemiesKilled: number, baseHpPercent: number): number {
+  return (salvageDeposited * 50) + (enemiesKilled * 10) + Math.floor(baseHpPercent * 50);
+}
+
+/**
+ * Reduced currency for game_over (lose) path: 25% of normal, floored.
+ */
+export function calculateReducedCurrency(salvageDeposited: number, enemiesKilled: number, baseHpPercent: number): number {
+  return Math.floor(calculateCurrency(salvageDeposited, enemiesKilled, baseHpPercent) * 0.25);
+}
+
+export function loadSaveData(): SaveData {
+  try {
+    const raw = localStorage.getItem(SAVE_KEY);
+    if (!raw) return { ...DEFAULT_SAVE, baseUpgrades: {} };
+    const parsed = JSON.parse(raw);
+    return {
+      currency: parsed.currency ?? 0,
+      runCount: parsed.runCount ?? 0,
+      baseUpgrades: parsed.baseUpgrades ?? {},
+    };
+  } catch {
+    return { ...DEFAULT_SAVE, baseUpgrades: {} };
+  }
+}
+
+export function saveSaveData(data: SaveData): void {
+  localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+}

--- a/src/systems/TowRopeSystem.test.ts
+++ b/src/systems/TowRopeSystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createSalvage, createDropoff } from '../entities/Entity';
+import { createSalvage, createDropoff, createHomeBase } from '../entities/Entity';
 import { Player } from '../entities/Player';
 import {
   TowRopeSystem,
@@ -259,6 +259,61 @@ describe('TowRopeSystem', () => {
 
       expect(deposited).toHaveLength(2);
       expect(system.getTowedItems()).toHaveLength(0);
+    });
+  });
+
+  describe('checkHomeDeposit', () => {
+    it('deposits salvage when it enters the home base radius', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(10, 0); // Within 150px radius
+      system.collect(salvage);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(1);
+      expect(deposited[0]).toBe(salvage);
+      expect(system.getTowedItems()).toHaveLength(0);
+      expect(salvage.towedByPlayer).toBe(false);
+      expect(salvage.active).toBe(false);
+    });
+
+    it('does not deposit salvage outside the home base radius', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(200, 0); // Beyond 150px radius
+      system.collect(salvage);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(0);
+      expect(system.getTowedItems()).toHaveLength(1);
+    });
+
+    it('ignores fading salvage', () => {
+      const homeBase = createHomeBase(0, 0);
+      const salvage = buildSalvage(10, 0);
+      system.collect(salvage);
+      system.getTowedItems()[0].fadeOut = 0.2;
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(0);
+    });
+
+    it('deposits multiple salvage items at once', () => {
+      const homeBase = createHomeBase(0, 0);
+      const s1 = buildSalvage(10, 0);
+      const s2 = buildSalvage(0, 10);
+      system.collect(s1);
+      system.collect(s2);
+
+      const deposited = system.checkHomeDeposit(homeBase);
+
+      expect(deposited).toHaveLength(2);
+      expect(system.getTowedItems()).toHaveLength(0);
+    });
+
+    it('has a static HOME_DEPOSIT_REWARD of 50', () => {
+      expect(TowRopeSystem.HOME_DEPOSIT_REWARD).toBe(50);
     });
   });
 

--- a/src/systems/TowRopeSystem.ts
+++ b/src/systems/TowRopeSystem.ts
@@ -1,4 +1,4 @@
-import { Salvage, Dropoff } from '../entities/Entity';
+import { Salvage, Dropoff, HomeBase } from '../entities/Entity';
 import { Player } from '../entities/Player';
 
 // Tuning constants — exported for tests and future adjustment
@@ -169,6 +169,30 @@ export class TowRopeSystem {
           item.salvage.active = false;
           this.items.splice(i, 1);
         }
+      }
+    }
+
+    return deposited;
+  }
+
+  /** Energy reward per salvage item deposited at the home base */
+  static readonly HOME_DEPOSIT_REWARD = 50;
+
+  /** Check if any towed salvage has entered the home base radius. Returns deposited salvage items. */
+  checkHomeDeposit(homeBase: HomeBase): Salvage[] {
+    const deposited: Salvage[] = [];
+
+    for (let i = this.items.length - 1; i >= 0; i--) {
+      const item = this.items[i];
+      if (item.fadeOut !== null) continue; // Already fading
+
+      const dx = item.salvage.x - homeBase.x;
+      const dy = item.salvage.y - homeBase.y;
+      if (dx * dx + dy * dy < homeBase.radius * homeBase.radius) {
+        deposited.push(item.salvage);
+        item.salvage.towedByPlayer = false;
+        item.salvage.active = false;
+        this.items.splice(i, 1);
       }
     }
 

--- a/src/systems/WaveSpawner.test.ts
+++ b/src/systems/WaveSpawner.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { spawnWave } from './WaveSpawner';
+
+describe('spawnWave', () => {
+  it('spawns 10 + runCount*5 enemies for runCount 1', () => {
+    const enemies = spawnWave(1);
+    expect(enemies).toHaveLength(15);
+  });
+
+  it('spawns 10 + runCount*5 enemies for runCount 3', () => {
+    const enemies = spawnWave(3);
+    expect(enemies).toHaveLength(25);
+  });
+
+  it('spawns enemies on an 800px circle around origin', () => {
+    const enemies = spawnWave(1);
+    for (const e of enemies) {
+      const dist = Math.sqrt(e.x * e.x + e.y * e.y);
+      expect(dist).toBeCloseTo(800, 0);
+    }
+  });
+
+  it('produces approximately 50% scouts, 30% brutes, 20% ranged', () => {
+    const enemies = spawnWave(2); // 20 enemies
+    const scouts = enemies.filter(e => e.subtype === 'scout').length;
+    const brutes = enemies.filter(e => e.subtype === 'brute').length;
+    const ranged = enemies.filter(e => e.subtype === 'ranged').length;
+
+    expect(scouts).toBe(10); // 50% of 20
+    expect(brutes).toBe(6);  // 30% of 20
+    expect(ranged).toBe(4);  // 20% of 20
+  });
+
+  it('marks all enemies as waveEnemy', () => {
+    const enemies = spawnWave(1);
+    for (const e of enemies) {
+      expect(e.waveEnemy).toBe(true);
+    }
+  });
+
+  it('makes all wave enemies visible', () => {
+    const enemies = spawnWave(1);
+    for (const e of enemies) {
+      expect(e.visible).toBe(true);
+    }
+  });
+
+  it('designates exactly one boss (a brute with 5x HP and 2x damage)', () => {
+    const enemies = spawnWave(1);
+    const bosses = enemies.filter(e => e.isBoss);
+    expect(bosses).toHaveLength(1);
+    expect(bosses[0].subtype).toBe('brute');
+
+    // Compare boss stats to a non-boss brute
+    const normalBrutes = enemies.filter(e => e.subtype === 'brute' && !e.isBoss);
+    if (normalBrutes.length > 0) {
+      // Boss has 5x HP of a normal brute at same difficulty
+      expect(bosses[0].maxHealth).toBe(normalBrutes[0].maxHealth * 5);
+      // Boss has 2x damage of a normal brute at same difficulty
+      expect(bosses[0].damage).toBe(normalBrutes[0].damage * 2);
+    }
+  });
+
+  it('scales enemies by difficulty based on runCount', () => {
+    const run1 = spawnWave(1);
+    const run3 = spawnWave(3);
+
+    // Find a non-boss scout from each wave
+    const scout1 = run1.find(e => e.subtype === 'scout' && !e.isBoss)!;
+    const scout3 = run3.find(e => e.subtype === 'scout' && !e.isBoss)!;
+
+    // Run 3 has higher difficulty (1 + 3*0.3 = 1.9) vs run 1 (1 + 1*0.3 = 1.3)
+    expect(scout3.maxHealth).toBeGreaterThan(scout1.maxHealth);
+  });
+});

--- a/src/systems/WaveSpawner.ts
+++ b/src/systems/WaveSpawner.ts
@@ -1,0 +1,50 @@
+import { Enemy, EnemySubtype, createEnemy } from '../entities/Entity';
+import { scaleEnemy } from '../world/POIGenerator';
+
+/**
+ * Spawn a wave of enemies in a circle around the origin.
+ * Returns the spawned enemies (caller adds them to the world entity list).
+ *
+ * @param runCount - Current run number (1-based). Controls wave size and difficulty.
+ */
+export function spawnWave(runCount: number): Enemy[] {
+  const totalEnemies = 10 + runCount * 5;
+  const difficulty = 1 + runCount * 0.3;
+  const spawnRadius = 800;
+  const enemies: Enemy[] = [];
+
+  for (let i = 0; i < totalEnemies; i++) {
+    // Distribute evenly around the circle
+    const angle = (i / totalEnemies) * Math.PI * 2;
+    const x = Math.cos(angle) * spawnRadius;
+    const y = Math.sin(angle) * spawnRadius;
+
+    // Mix: 50% scouts, 30% brutes, 20% ranged
+    let subtype: EnemySubtype;
+    const ratio = i / totalEnemies;
+    if (ratio < 0.5) {
+      subtype = 'scout';
+    } else if (ratio < 0.8) {
+      subtype = 'brute';
+    } else {
+      subtype = 'ranged';
+    }
+
+    const enemy = createEnemy(x, y, subtype);
+    scaleEnemy(enemy, difficulty);
+    enemy.waveEnemy = true;
+    enemy.visible = true; // Wave enemies are always visible
+    enemies.push(enemy);
+  }
+
+  // Designate one boss: the first brute, upgraded with 5x HP and 2x damage
+  const firstBrute = enemies.find(e => e.subtype === 'brute');
+  if (firstBrute) {
+    firstBrute.health *= 5;
+    firstBrute.maxHealth = firstBrute.health;
+    firstBrute.damage *= 2;
+    firstBrute.isBoss = true;
+  }
+
+  return enemies;
+}

--- a/src/ui/HUD.test.ts
+++ b/src/ui/HUD.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { HUD } from './HUD';
+import { HUD, formatTime } from './HUD';
 import { Player } from '../entities/Player';
 
 function createMockCtx(): CanvasRenderingContext2D {
@@ -45,5 +45,88 @@ describe('HUD', () => {
     expect(allText.some((t: string) => t.includes('HP:'))).toBe(true);
     expect(allText.some((t: string) => t.includes('42'))).toBe(true);
     expect(allText.some((t: string) => t.includes('100'))).toBe(true);
+  });
+
+  it('renders the run timer in MM:SS format when runTimer is provided', () => {
+    const hud = new HUD();
+    const ctx = createMockCtx();
+    const player = new Player();
+
+    hud.render(ctx, player, 800, 600, 305); // 5:05
+
+    const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls;
+    const allText = fillTextCalls.map((c: unknown[]) => c[0] as string);
+
+    expect(allText.some((t: string) => t === '5:05')).toBe(true);
+  });
+
+  it('does not render run timer when runTimer is -1 (default)', () => {
+    const hud = new HUD();
+    const ctx = createMockCtx();
+    const player = new Player();
+
+    hud.render(ctx, player, 800, 600);
+
+    const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls;
+    const allText = fillTextCalls.map((c: unknown[]) => c[0] as string);
+
+    // No MM:SS formatted timer should appear
+    expect(allText.some((t: string) => /^\d+:\d{2}$/.test(t))).toBe(false);
+  });
+
+  it('renders FINAL WAVE text when runTimer is exactly 0', () => {
+    const hud = new HUD();
+    const ctx = createMockCtx();
+    const player = new Player();
+
+    hud.render(ctx, player, 800, 600, 0);
+
+    const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls;
+    const allText = fillTextCalls.map((c: unknown[]) => c[0] as string);
+
+    expect(allText.some((t: string) => t === 'FINAL WAVE')).toBe(true);
+    // Should NOT show 0:00 countdown
+    expect(allText.some((t: string) => t === '0:00')).toBe(false);
+  });
+
+  it('renders timer at top-center of the canvas', () => {
+    const hud = new HUD();
+    const ctx = createMockCtx();
+    const player = new Player();
+
+    hud.render(ctx, player, 800, 600, 600); // 10:00
+
+    const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls;
+    const timerCall = fillTextCalls.find((c: unknown[]) => c[0] === '10:00');
+
+    expect(timerCall).toBeDefined();
+    // x should be at canvas center (800 / 2 = 400)
+    expect(timerCall![1]).toBe(400);
+  });
+});
+
+describe('formatTime', () => {
+  it('formats 600 seconds as 10:00', () => {
+    expect(formatTime(600)).toBe('10:00');
+  });
+
+  it('formats 61 seconds as 1:01', () => {
+    expect(formatTime(61)).toBe('1:01');
+  });
+
+  it('formats 0 seconds as 0:00', () => {
+    expect(formatTime(0)).toBe('0:00');
+  });
+
+  it('formats 59.9 seconds as 0:59', () => {
+    expect(formatTime(59.9)).toBe('0:59');
+  });
+
+  it('clamps negative values to 0:00', () => {
+    expect(formatTime(-5)).toBe('0:00');
+  });
+
+  it('formats 305 seconds as 5:05', () => {
+    expect(formatTime(305)).toBe('5:05');
   });
 });

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -1,6 +1,15 @@
 import { Player } from '../entities/Player';
+import { HomeBase } from '../entities/Entity';
 import { getThreatLevel } from '../world/World';
 import { getTheme } from '../themes/theme';
+
+/** Format seconds into MM:SS string. Exported for testing. */
+export function formatTime(seconds: number): string {
+  const clamped = Math.max(0, seconds);
+  const m = Math.floor(clamped / 60);
+  const s = Math.floor(clamped % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
 
 export class HUD {
   private fps = 0;
@@ -22,6 +31,9 @@ export class HUD {
     player: Player,
     canvasWidth: number,
     canvasHeight: number,
+    runTimer: number = -1,
+    homeBase?: HomeBase,
+    defenseHint?: { show: boolean; defenseCount: number; maxDefenses: number },
   ): void {
     const padding = 20;
     const barWidth = 200;
@@ -45,24 +57,48 @@ export class HUD {
       `HP: ${Math.ceil(player.health)}/${player.maxHealth}${player.shieldActive ? ' [SHIELD]' : ''}`
     );
 
+    // Base HP bar (below player HP bar)
+    if (homeBase) {
+      const baseBarY = y + barHeight + 4;
+      const baseRatio = homeBase.health / homeBase.maxHealth;
+      // Interpolate color from cyan to red based on damage
+      const r = Math.round(100 + (255 - 100) * (1 - baseRatio));
+      const g = Math.round(220 * baseRatio + 60 * (1 - baseRatio));
+      const b = Math.round(255 * baseRatio + 60 * (1 - baseRatio));
+      const baseColor = `rgb(${r}, ${g}, ${b})`;
+      this.renderBar(
+        ctx,
+        padding,
+        baseBarY,
+        barWidth,
+        barHeight,
+        baseRatio,
+        baseColor,
+        `BASE: ${Math.ceil(homeBase.health)}/${homeBase.maxHealth}`
+      );
+    }
+
+    // Offset subsequent elements when base bar is present
+    const baseBarOffset = homeBase ? barHeight + 4 : 0;
+
     // Energy counter
     ctx.fillStyle = theme.ui.textPrimary;
     ctx.shadowColor = theme.ui.textPrimary;
     ctx.shadowBlur = 5;
-    ctx.fillText(`Energy: ${Math.floor(player.energy)}`, padding, y + barHeight + 24);
+    ctx.fillText(`Energy: ${Math.floor(player.energy)}`, padding, y + barHeight + baseBarOffset + 24);
     ctx.shadowBlur = 0;
 
     // Distance from origin
     const dist = Math.floor(Math.sqrt(player.x * player.x + player.y * player.y));
     ctx.fillStyle = theme.ui.textSecondary;
-    ctx.fillText(`RANGE: ${dist}m`, padding, y + barHeight + 44);
+    ctx.fillText(`RANGE: ${dist}m`, padding, y + barHeight + baseBarOffset + 44);
 
     // Threat level
     const threat = getThreatLevel(player.x, player.y);
     ctx.fillStyle = threat.color;
     ctx.shadowColor = threat.color;
     ctx.shadowBlur = 3;
-    ctx.fillText(`THREAT: ${threat.label}`, padding, y + barHeight + 64);
+    ctx.fillText(`THREAT: ${threat.label}`, padding, y + barHeight + baseBarOffset + 64);
     ctx.shadowBlur = 0;
 
     // Coordinates
@@ -71,8 +107,38 @@ export class HUD {
     ctx.fillText(
       `POS: ${Math.floor(player.x)}, ${Math.floor(player.y)}`,
       padding,
-      y + barHeight + 82
+      y + barHeight + baseBarOffset + 82
     );
+
+    // Run timer (top center) — only shown during timed runs
+    if (runTimer >= 0) {
+      ctx.save();
+      ctx.font = 'bold 20px monospace';
+      ctx.textAlign = 'center';
+      if (runTimer === 0) {
+        // Final wave in progress — show FINAL WAVE instead of 00:00
+        const pulse = Math.sin(performance.now() / 400) * 0.5 + 0.5;
+        const alpha = 0.6 + pulse * 0.4;
+        ctx.fillStyle = `rgba(255, 200, 60, ${alpha})`;
+        ctx.shadowColor = 'rgba(255, 200, 60, 0.8)';
+        ctx.shadowBlur = 8;
+        ctx.fillText('FINAL WAVE', canvasWidth / 2, y + 20);
+      } else if (runTimer <= 60) {
+        // Pulsing red in the final 60 seconds
+        const pulse = Math.sin(performance.now() / 500) * 0.5 + 0.5; // 0..1
+        const alpha = 0.5 + pulse * 0.5; // 0.5..1.0
+        ctx.fillStyle = `rgba(255, 60, 60, ${alpha})`;
+        ctx.shadowColor = 'rgba(255, 60, 60, 0.8)';
+        ctx.shadowBlur = 6;
+        ctx.fillText(formatTime(runTimer), canvasWidth / 2, y + 20);
+      } else {
+        ctx.fillStyle = '#ffffff';
+        ctx.shadowColor = '#ffffff';
+        ctx.shadowBlur = 4;
+        ctx.fillText(formatTime(runTimer), canvasWidth / 2, y + 20);
+      }
+      ctx.restore();
+    }
 
     // Score (top right)
     ctx.font = '16px monospace';
@@ -102,6 +168,19 @@ export class HUD {
     ctx.globalAlpha = 0.5;
     ctx.fillText(`${this.fps} FPS`, padding, canvasHeight - 10);
     ctx.globalAlpha = 1;
+
+    // Defense placement hint — shown when near base with room for more defenses
+    if (defenseHint && defenseHint.show && defenseHint.defenseCount < defenseHint.maxDefenses
+        && (player.energy >= 75)) {
+      ctx.font = '13px monospace';
+      ctx.textAlign = 'center';
+      ctx.fillStyle = 'rgba(170, 220, 170, 0.85)';
+      const hintY = canvasHeight - 35;
+      ctx.fillText('[T] Turret (100)  |  [R] Repair (75)', canvasWidth / 2, hintY);
+      ctx.font = '10px monospace';
+      ctx.fillStyle = 'rgba(136, 170, 136, 0.6)';
+      ctx.fillText(`Defenses: ${defenseHint.defenseCount}/${defenseHint.maxDefenses}`, canvasWidth / 2, hintY + 14);
+    }
 
     ctx.restore();
   }

--- a/src/ui/ResultsScreen.test.ts
+++ b/src/ui/ResultsScreen.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ResultsScreen, RunStats } from './ResultsScreen';
+
+// Mock getTheme to return a simple theme object
+vi.mock('../themes/theme', () => ({
+  getTheme: () => ({
+    entities: { enemy: '#ff0000' },
+    ui: { textPrimary: '#ffffff', statsText: '#cccccc', border: '#444444' },
+    radar: { primary: '#00ff41' },
+    events: { collect: '#ffaa00' },
+  }),
+}));
+
+function makeStats(overrides: Partial<RunStats> = {}): RunStats {
+  return {
+    salvageDeposited: 5,
+    enemiesKilled: 10,
+    baseHpPercent: 0.75,
+    currencyEarned: 475,
+    ...overrides,
+  };
+}
+
+describe('ResultsScreen', () => {
+  let screen: ResultsScreen;
+
+  beforeEach(() => {
+    screen = new ResultsScreen();
+  });
+
+  it('starts not visible', () => {
+    expect(screen.isVisible()).toBe(false);
+  });
+
+  it('becomes visible after show()', () => {
+    const canvas = document.createElement('canvas');
+    screen.show(canvas, makeStats(), () => {});
+    expect(screen.isVisible()).toBe(true);
+  });
+
+  it('becomes not visible after hide()', () => {
+    const canvas = document.createElement('canvas');
+    screen.show(canvas, makeStats(), () => {});
+    screen.hide(canvas);
+    expect(screen.isVisible()).toBe(false);
+  });
+
+  it('calls onContinue and hides when Continue button is clicked', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+
+    const onContinue = vi.fn();
+    screen.show(canvas, makeStats(), onContinue);
+
+    // Set button bounds manually (render would normally do this but jsdom has no canvas context)
+    screen.setButtonBounds({ x: 300, y: 350, width: 200, height: 50 });
+
+    // Click inside button bounds
+    const clickEvent = new MouseEvent('click', { clientX: 400, clientY: 375 });
+    canvas.dispatchEvent(clickEvent);
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(screen.isVisible()).toBe(false);
+  });
+
+  it('does not call onContinue when clicking outside button', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 800;
+    canvas.height = 600;
+    canvas.getBoundingClientRect = () => ({ left: 0, top: 0, right: 800, bottom: 600, width: 800, height: 600, x: 0, y: 0, toJSON: () => ({}) });
+
+    const onContinue = vi.fn();
+    screen.show(canvas, makeStats(), onContinue);
+    screen.setButtonBounds({ x: 300, y: 350, width: 200, height: 50 });
+
+    // Click outside button bounds
+    const clickEvent = new MouseEvent('click', { clientX: 100, clientY: 100 });
+    canvas.dispatchEvent(clickEvent);
+
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.isVisible()).toBe(true);
+  });
+
+  it('stores stats for rendering', () => {
+    const canvas = document.createElement('canvas');
+    const stats = makeStats({ currencyEarned: 999 });
+    screen.show(canvas, stats, () => {});
+    expect(screen.getStats()).toEqual(stats);
+  });
+});
+
+describe('ResultsScreen for game_over (failed run)', () => {
+  it('shows failed state with reduced currency', () => {
+    const screen = new ResultsScreen();
+    const canvas = document.createElement('canvas');
+    const stats = makeStats({ currencyEarned: 60 });
+    screen.show(canvas, stats, () => {}, true);
+    expect(screen.isVisible()).toBe(true);
+    expect(screen.isFailed()).toBe(true);
+  });
+});

--- a/src/ui/ResultsScreen.ts
+++ b/src/ui/ResultsScreen.ts
@@ -1,0 +1,134 @@
+import { getTheme } from '../themes/theme';
+
+export interface RunStats {
+  salvageDeposited: number;
+  enemiesKilled: number;
+  baseHpPercent: number;
+  currencyEarned: number;
+}
+
+export class ResultsScreen {
+  private visible = false;
+  private failed = false;
+  private onContinue: (() => void) | null = null;
+  private buttonBounds = { x: 0, y: 0, width: 0, height: 0 };
+  private clickHandler: ((e: MouseEvent) => void) | null = null;
+  private stats: RunStats | null = null;
+
+  show(canvas: HTMLCanvasElement, stats: RunStats, onContinue: () => void, failed = false): void {
+    this.visible = true;
+    this.failed = failed;
+    this.onContinue = onContinue;
+    this.stats = stats;
+
+    this.clickHandler = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+
+      if (
+        mx >= this.buttonBounds.x &&
+        mx <= this.buttonBounds.x + this.buttonBounds.width &&
+        my >= this.buttonBounds.y &&
+        my <= this.buttonBounds.y + this.buttonBounds.height
+      ) {
+        this.hide(canvas);
+        onContinue();
+      }
+    };
+
+    canvas.addEventListener('click', this.clickHandler);
+  }
+
+  hide(canvas: HTMLCanvasElement): void {
+    this.visible = false;
+    if (this.clickHandler) {
+      canvas.removeEventListener('click', this.clickHandler);
+      this.clickHandler = null;
+    }
+  }
+
+  isVisible(): boolean {
+    return this.visible;
+  }
+
+  isFailed(): boolean {
+    return this.failed;
+  }
+
+  getStats(): RunStats | null {
+    return this.stats;
+  }
+
+  /** Expose button bounds for testing (render sets this normally) */
+  setButtonBounds(bounds: { x: number; y: number; width: number; height: number }): void {
+    this.buttonBounds = bounds;
+  }
+
+  render(ctx: CanvasRenderingContext2D, canvasWidth: number, canvasHeight: number): void {
+    if (!this.visible || !this.stats) return;
+
+    // Dim overlay
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.8)';
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+    const cx = canvasWidth / 2;
+    const cy = canvasHeight / 2;
+
+    const theme = getTheme();
+
+    ctx.save();
+
+    // Title
+    const titleColor = this.failed ? theme.entities.enemy : theme.radar.primary;
+    const titleText = this.failed ? 'RUN FAILED' : 'RUN COMPLETE';
+    ctx.shadowColor = titleColor;
+    ctx.shadowBlur = 20;
+    ctx.font = 'bold 48px monospace';
+    ctx.fillStyle = titleColor;
+    ctx.textAlign = 'center';
+    ctx.fillText(titleText, cx, cy - 130);
+    ctx.shadowBlur = 0;
+
+    // Stats
+    ctx.font = '16px monospace';
+    ctx.fillStyle = theme.ui.statsText;
+    const lineH = 28;
+    let y = cy - 70;
+
+    ctx.fillText(`Salvage Deposited: ${this.stats.salvageDeposited}`, cx, y);
+    y += lineH;
+    ctx.fillText(`Enemies Killed: ${this.stats.enemiesKilled}`, cx, y);
+    y += lineH;
+    ctx.fillText(`Base HP Remaining: ${Math.round(this.stats.baseHpPercent * 100)}%`, cx, y);
+    y += lineH;
+
+    // Currency earned (highlighted)
+    y += 8;
+    const currencyColor = this.failed ? theme.entities.enemy : theme.events.collect;
+    ctx.font = 'bold 22px monospace';
+    ctx.fillStyle = currencyColor;
+    ctx.shadowColor = currencyColor;
+    ctx.shadowBlur = 6;
+    const rewardLabel = this.failed ? 'SALVAGE RECOVERED' : 'CURRENCY EARNED';
+    ctx.fillText(`${rewardLabel}: ${this.stats.currencyEarned}`, cx, y);
+    ctx.shadowBlur = 0;
+
+    // Continue button
+    const btnWidth = 200;
+    const btnHeight = 50;
+    const btnX = cx - btnWidth / 2;
+    const btnY = cy + 80;
+    this.buttonBounds = { x: btnX, y: btnY, width: btnWidth, height: btnHeight };
+
+    ctx.strokeStyle = theme.ui.border;
+    ctx.lineWidth = 2;
+    ctx.strokeRect(btnX, btnY, btnWidth, btnHeight);
+
+    ctx.font = '20px monospace';
+    ctx.fillStyle = theme.ui.textPrimary;
+    ctx.fillText('CONTINUE', cx, btnY + 32);
+
+    ctx.restore();
+  }
+}


### PR DESCRIPTION
## Summary
Combined delivery of the full Game Design Document implementation — 11 work items from orchestrator campaign-3396f1, consolidated into a single PR for clean merging.

This replaces individual PRs #50-59 which had cherry-pick conflicts. PR #49 (state machine refactor) was already merged separately.

## Changes

### Phase 1 — Core Run Loop
- **Run timer**: 10-minute countdown, pulsing red in final 60s, triggers final wave on expiry
- **Home base HP**: 500 HP with cyan→red damage tinting, acts as salvage deposit point
- **Final wave**: Spawns scouts/brutes/ranged + boss brute around origin, enemies target the base
- **Results screen**: Currency earned from salvage/kills/base HP, persisted to localStorage
- **Game over path**: Reduced (25%) rewards on death, returns to base_mode

### Phase 2 — Base Building
- **Defense entities**: Turret (auto-fire at enemies) and Repair Station (heal player nearby)
- **Placement**: T/R keys near home base, 100/75 energy cost, max 3 slots
- **Defense behavior**: Turret AI targeting, repair healing, enemy damage to defenses
- **Persistent upgrades**: 4 between-run upgrades (base HP, cargo, energy, defense slots)

### Phase 3 — Combat Depth
- **Combo system**: Blast→Drone (2x dmg), Regen→Dash (1.5x range), Dash→Blast (1.5x radius)

### Integration
- Player teleport to base on wave start with auto-salvage deposit
- Death particles wired into campaign combat/ability systems
- "WAVE INCOMING" / "FINAL WAVE" HUD display

## Test plan
- [x] `npm run build` — clean
- [x] `npm run test` — 366 tests pass
- [ ] Play full loop: menu → base_mode → run → final wave → results → base_mode → second run

Closes campaign-3396f1 (11 work items). Supersedes PRs #50-59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)