### PR TITLE
Enemies aggro when hit by player, even outside chase range

### DIFF
--- a/src/entities/Entity.ts
+++ b/src/entities/Entity.ts
@@ -46,6 +46,8 @@ export interface Enemy extends Entity {
   waveEnemy: boolean;
   /** Whether this enemy is a wave boss (renders larger) */
   isBoss: boolean;
+  /** Whether this enemy has been aggro'd by taking player damage (chases regardless of range) */
+  aggro: boolean;
 }
 
 export type AllySubtype = 'healer' | 'shield' | 'beacon';
@@ -187,6 +189,7 @@ export function createEnemy(x: number, y: number, subtype?: EnemySubtype): Enemy
     wanderTimer: 1 + Math.random() * 2,
     waveEnemy: false,
     isBoss: false,
+    aggro: false,
   };
 }
 

--- a/src/systems/AbilitySystem.test.ts
+++ b/src/systems/AbilitySystem.test.ts
@@ -104,6 +104,19 @@ describe('AbilitySystem', () => {
       expect(texts[0].text).toBe('-20');
       expect(texts[0].color).toBe('#ff4141');
     });
+
+    it('sets aggro on enemies hit by blast', () => {
+      const { system, player } = buildAbilitySystem();
+      player.x = 0;
+      player.y = 0;
+      const enemy = createEnemy(100, 0, 'brute');
+      enemy.health = 80;
+      expect(enemy.aggro).toBe(false);
+
+      system.activate('damage_blast', [enemy], () => {});
+
+      expect(enemy.aggro).toBe(true);
+    });
   });
 
   describe('heal over time', () => {
@@ -199,6 +212,21 @@ describe('AbilitySystem', () => {
       const { system } = buildAbilitySystem();
       const ability = system.getAbility('helper_drone')!;
       expect(ability.cooldown).toBe(15);
+    });
+
+    it('drone sets aggro on enemies it damages', () => {
+      const { system, player } = buildAbilitySystem();
+      player.x = 0;
+      player.y = 0;
+      const enemy = createEnemy(5, 0, 'brute');
+      enemy.health = 80;
+      expect(enemy.aggro).toBe(false);
+      const entities: GameEntity[] = [enemy];
+
+      system.activate('helper_drone', entities, () => {});
+      system.update(1, entities, () => {});
+
+      expect(enemy.aggro).toBe(true);
     });
 
     it('drone kills enemies and awards score', () => {
@@ -410,6 +438,23 @@ describe('AbilitySystem', () => {
       expect(player.kills).toBe(1);
       expect(player.score).toBe(50);
       expect(player.energy).toBe(5);
+    });
+
+    it('sets aggro on enemy hit by missile', () => {
+      const { system, player } = buildAbilitySystem();
+      player.x = 0;
+      player.y = 0;
+      const enemy = createEnemy(150, 0, 'brute');
+      enemy.visible = true;
+      enemy.health = 80;
+      expect(enemy.aggro).toBe(false);
+      const entities: GameEntity[] = [enemy];
+
+      system.activate('homing_missile', entities, () => {});
+      for (let i = 0; i < 80; i++) system.update(0.05, entities, () => {});
+
+      expect(enemy.health).toBeLessThan(80);
+      expect(enemy.aggro).toBe(true);
     });
 
     it('expires after 4 seconds if it misses', () => {

--- a/src/systems/AbilitySystem.ts
+++ b/src/systems/AbilitySystem.ts
@@ -223,6 +223,7 @@ export class AbilitySystem {
 
       if (distSq < blastRadius * blastRadius) {
         enemy.health -= blastDamage;
+        enemy.aggro = true;
         addFloatingText(`-${blastDamage}`, enemy.x, enemy.y, getTheme().events.damage);
 
         if (enemy.health <= 0) {
@@ -306,6 +307,7 @@ export class AbilitySystem {
         if (dist < 20) {
           const dmg = drone.damage * dt;
           nearest.health -= dmg;
+          nearest.aggro = true;
           if (nearest.health <= 0 && nearest.active) {
             nearest.active = false;
             const deathColor = nearest.subtype === 'ranged' ? getTheme().entities.enemyRanged : getTheme().entities.enemy;
@@ -404,6 +406,7 @@ export class AbilitySystem {
       // Handle collision
       if (hitEnemy) {
         hitEnemy.health -= missile.damage;
+        hitEnemy.aggro = true;
         addFloatingText(`-${missile.damage}`, hitEnemy.x, hitEnemy.y, getTheme().effects.missile);
         onImpact(hitEnemy.x, hitEnemy.y, missile.x, missile.y, getTheme().effects.missile);
         this.onShake(7);

--- a/src/systems/CombatSystem.test.ts
+++ b/src/systems/CombatSystem.test.ts
@@ -236,6 +236,73 @@ describe('CombatSystem', () => {
     expect(enemy.x).toBeLessThan(initialX); // moved toward player at x=250
   });
 
+  describe('aggro on damage', () => {
+    it('aggroed enemies chase the player even when beyond normal chase range', () => {
+      const enemy = createEnemy(1000, 0, 'scout');
+      enemy.chaseRange = 200;
+      enemy.aggro = true;
+      const initialX = enemy.x;
+
+      combat.update([enemy], player, 1);
+
+      // Should chase toward player at origin despite being 1000px away (chaseRange=200)
+      expect(enemy.x).toBeLessThan(initialX);
+    });
+
+    it('non-aggroed enemies outside chase range do not chase', () => {
+      const enemy = createEnemy(1000, 0, 'scout');
+      enemy.chaseRange = 200;
+      enemy.aggro = false;
+      enemy.wanderAngle = Math.PI / 2; // wander perpendicular, not toward player
+      enemy.wanderTimer = 5;
+
+      combat.update([enemy], player, 0.5);
+
+      // Should NOT have moved significantly toward player
+      expect(enemy.x).toBeGreaterThan(990);
+    });
+
+    it('ram sets aggro on hit enemy', () => {
+      const enemy = createEnemy(5, 0, 'scout');
+      enemy.health = 50;
+      expect(enemy.aggro).toBe(false);
+
+      combat.update([enemy], player, 0.016, true, 15);
+
+      expect(enemy.aggro).toBe(true);
+    });
+
+    it('turret projectile sets aggro on hit enemy', () => {
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.health = 50;
+      expect(enemy.aggro).toBe(false);
+
+      combat.turretProjectiles.push({
+        x: 100, y: 0,
+        vx: 0, vy: 0,
+        damage: 5,
+        active: true,
+        lifetime: 3,
+      });
+
+      combat.update([enemy], player, 0.016);
+
+      expect(enemy.aggro).toBe(true);
+    });
+
+    it('normal chase range behavior still works for non-aggroed enemies', () => {
+      const enemy = createEnemy(100, 0, 'scout');
+      enemy.chaseRange = 200;
+      enemy.aggro = false;
+      const initialX = enemy.x;
+
+      combat.update([enemy], player, 1);
+
+      // Within chase range, should still chase
+      expect(enemy.x).toBeLessThan(initialX);
+    });
+  });
+
   describe('targetPos override', () => {
     it('enemies chase targetPos instead of player when provided', () => {
       const enemy = createEnemy(100, 0, 'scout');

--- a/src/systems/CombatSystem.ts
+++ b/src/systems/CombatSystem.ts
@@ -133,8 +133,8 @@ export class CombatSystem {
       // Stop at standoff distance instead of stacking on top of the target
       const standoffDist = enemy.subtype === 'brute' ? 20 : 25;
       const enemyAccel = enemy.speed * enemy.friction;
-      // Wave enemies always chase (infinite range); normal enemies use chaseRange
-      const inChaseRange = enemy.waveEnemy || targetDistSq < enemy.chaseRange * enemy.chaseRange;
+      // Wave enemies and aggroed enemies always chase; normal enemies use chaseRange
+      const inChaseRange = enemy.waveEnemy || enemy.aggro || targetDistSq < enemy.chaseRange * enemy.chaseRange;
 
       if (enemy.subtype !== 'ranged' && inChaseRange && targetDistSq > standoffDist * standoffDist) {
         const dist = Math.sqrt(targetDistSq);
@@ -195,6 +195,7 @@ export class CombatSystem {
           // Ram: one hit per enemy per dash
           this.ramHitEnemies.add(enemy);
           enemy.health -= ramDamage;
+          enemy.aggro = true;
           addFloatingText(`-${ramDamage}`, enemy.x, enemy.y, getTheme().effects.missile);
           // Knockback: blend player movement direction with player→enemy direction
           // so enemies deflect outward to whichever side they're on
@@ -307,6 +308,7 @@ export class CombatSystem {
         const edy = p.y - enemy.y;
         if (edx * edx + edy * edy < 20 * 20) {
           enemy.health -= p.damage;
+          enemy.aggro = true;
           addFloatingText(`-${p.damage}`, enemy.x, enemy.y, '#00ddff');
           if (enemy.health <= 0 && enemy.active) {
             enemy.active = false;

--- a/src/systems/OrbitBotSystem.ts
+++ b/src/systems/OrbitBotSystem.ts
@@ -255,6 +255,7 @@ export class OrbitBotSystem {
     if (distSq < CONTACT_RANGE_SQ) {
       const dmg = DAMAGE_PER_SECOND * dt;
       target.health -= dmg;
+      target.aggro = true;
 
       // Batch floating text
       bot.damageAccum += dmg;


### PR DESCRIPTION
## Summary

When the player hits an enemy from outside its normal chase range (via blast, drone, missile, dash ram, turret, or orbit bot), the enemy now enters an aggro state and begins chasing/attacking the player regardless of distance.

Closes #67

## Changes

Adds an `aggro` boolean to the `Enemy` interface (defaults to `false`). Every player-controlled damage source sets `aggro = true` on the target enemy. The chase range check in `CombatSystem.update()` now treats aggroed enemies the same as wave enemies — they chase without range limits.

**Files changed:**
- `src/entities/Entity.ts` — added `aggro: boolean` to `Enemy` interface and factory
- `src/systems/CombatSystem.ts` — set aggro on ram/turret damage, include aggro in chase check
- `src/systems/AbilitySystem.ts` — set aggro on blast/drone/missile damage
- `src/systems/OrbitBotSystem.ts` — set aggro on orbit bot contact damage

## Decisions Made

| Question | Decision | Rationale |
|----------|----------|-----------|
| Should aggro expire? | No — persists until death or cleanup | Enemies >2000px are cleaned up by World.cleanup() anyway |
| What counts as player damage? | All 6 sources: blast, drone, missile, ram, turret, orbit bot | All are player-controlled |
| How to store aggro? | Boolean flag on Enemy, like `waveEnemy` | Simplest approach, follows existing pattern |

## Test Coverage

- 8 new tests across CombatSystem and AbilitySystem test suites
- Tests verify: aggro flag set on ram, turret, blast, drone, missile hits
- Tests verify: aggroed enemies chase beyond normal range
- Tests verify: non-aggroed enemies still respect chase range
- Full suite: 395 tests passing, clean typecheck

## Quality Gates

- [x] Tests passing (395/395)
- [x] TypeScript strict mode — no errors
- [x] No new dependencies

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2