### PR TITLE
OrbitBot projectile attacks and orbit tuning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1327,6 +1327,35 @@ const loop = new GameLoop({
       }
     }
 
+    // Render orbit bot projectiles
+    {
+      const projs = orbitBotSystem.botProjectiles;
+      let hasActive = false;
+      for (let i = 0; i < projs.length; i++) {
+        if (projs[i].active) { hasActive = true; break; }
+      }
+      if (hasActive) {
+        ctx.save();
+        ctx.shadowColor = '#00ffff';
+        ctx.shadowBlur = 6;
+        ctx.fillStyle = '#00ffff';
+        ctx.beginPath();
+        for (let i = 0; i < projs.length; i++) {
+          const p = projs[i];
+          if (!p.active) continue;
+          const prx = p.x - player.x;
+          const pry = p.y - player.y;
+          if (prx * prx + pry * pry > viewRadiusSq) continue;
+          const px = cx + prx;
+          const py = cy + pry;
+          ctx.moveTo(px + 2, py);
+          ctx.arc(px, py, 2, 0, Math.PI * 2);
+        }
+        ctx.fill();
+        ctx.restore();
+      }
+    }
+
     // Render missiles
     for (const missile of abilitySystem.missiles) {
       const mrx = missile.x - player.x;

--- a/src/systems/OrbitBotSystem.test.ts
+++ b/src/systems/OrbitBotSystem.test.ts
@@ -143,10 +143,12 @@ describe('OrbitBotSystem', () => {
       expect(system.bot.state).toBe(OrbitBotState.OrbitingEnemy);
     });
 
-    it('orbits faster around enemies than around player', () => {
-      // The angular speed around enemies (4 rad/s) should be higher than player (2 rad/s)
-      // We verify this indirectly: the bot's ENEMY_ANGULAR_SPEED > PLAYER_ANGULAR_SPEED
-      expect(OrbitBotSystem.ENEMY_ANGULAR_SPEED).toBeGreaterThan(OrbitBotSystem.PLAYER_ANGULAR_SPEED);
+    it('enemy angular speed is tuned to 2.8 rad/s', () => {
+      expect(OrbitBotSystem.ENEMY_ANGULAR_SPEED).toBe(2.8);
+    });
+
+    it('player angular speed remains at 2 rad/s', () => {
+      expect(OrbitBotSystem.PLAYER_ANGULAR_SPEED).toBe(2);
     });
   });
 
@@ -194,26 +196,46 @@ describe('OrbitBotSystem', () => {
     });
   });
 
-  describe('combat', () => {
-    it('deals damage to target enemy while orbiting it', () => {
+  describe('projectile combat', () => {
+    it('deals damage to target enemy via projectiles while orbiting it', () => {
       const enemy = makeEnemy(80, 0, 100);
       const entities: GameEntity[] = [enemy];
       const initialHealth = enemy.health;
 
-      // Let bot reach and orbit enemy, dealing damage
-      for (let i = 0; i < 180; i++) {
+      // Let bot reach and orbit enemy, firing projectiles
+      for (let i = 0; i < 300; i++) {
         system.update(1 / 60, entities, addFloatingText, onDeath);
       }
 
       expect(enemy.health).toBeLessThan(initialHealth);
     });
 
-    it('returns to player when target enemy dies', () => {
+    it('fires projectiles that become active during OrbitingEnemy state', () => {
+      const enemy = makeEnemy(80, 0, 100);
+      const entities: GameEntity[] = [enemy];
+
+      // Let bot reach enemy
+      for (let i = 0; i < 120; i++) {
+        system.update(1 / 60, entities, addFloatingText, onDeath);
+      }
+      expect(system.bot.state).toBe(OrbitBotState.OrbitingEnemy);
+
+      // Run a few more frames to let a projectile fire
+      for (let i = 0; i < 60; i++) {
+        system.update(1 / 60, entities, addFloatingText, onDeath);
+      }
+
+      // At least one projectile should have been active at some point
+      // (it may have hit already, so check if damage was dealt)
+      expect(enemy.health).toBeLessThan(100);
+    });
+
+    it('returns to player when target enemy dies from projectiles', () => {
       const enemy = makeEnemy(80, 0, 5); // Low HP, will die quickly
       const entities: GameEntity[] = [enemy];
 
-      // Let bot kill the enemy
-      for (let i = 0; i < 300; i++) {
+      // Let bot kill the enemy via projectiles
+      for (let i = 0; i < 600; i++) {
         system.update(1 / 60, entities, addFloatingText, onDeath);
         if (!enemy.active) break;
       }
@@ -230,7 +252,7 @@ describe('OrbitBotSystem', () => {
       const enemy = makeEnemy(80, 0, 100);
       const entities: GameEntity[] = [enemy];
 
-      for (let i = 0; i < 180; i++) {
+      for (let i = 0; i < 300; i++) {
         system.update(1 / 60, entities, addFloatingText, onDeath);
       }
 
@@ -243,13 +265,48 @@ describe('OrbitBotSystem', () => {
       const initialScore = player.score;
       const initialKills = player.kills;
 
-      for (let i = 0; i < 300; i++) {
+      for (let i = 0; i < 600; i++) {
         system.update(1 / 60, entities, addFloatingText, onDeath);
         if (!enemy.active) break;
       }
 
       expect(player.score).toBeGreaterThan(initialScore);
       expect(player.kills).toBeGreaterThan(initialKills);
+    });
+
+    it('projectiles deactivate after their lifetime expires', () => {
+      const enemy = makeEnemy(500, 0, 100); // Far away — projectiles won't hit
+      const entities: GameEntity[] = [enemy];
+
+      // Move bot manually to orbiting state with a far target
+      // We'll put an enemy at 80 to trigger chase, then move it far
+      const closeEnemy = makeEnemy(80, 0, 100);
+      const closeEntities: GameEntity[] = [closeEnemy];
+
+      // Let bot reach and orbit
+      for (let i = 0; i < 120; i++) {
+        system.update(1 / 60, closeEntities, addFloatingText, onDeath);
+      }
+      expect(system.bot.state).toBe(OrbitBotState.OrbitingEnemy);
+
+      // Now move enemy far so projectiles can't hit
+      closeEnemy.x = 500;
+      closeEnemy.y = 0;
+
+      // Fire some projectiles
+      for (let i = 0; i < 60; i++) {
+        system.update(1 / 60, closeEntities, addFloatingText, onDeath);
+      }
+
+      // Wait for projectiles to expire (0.5s lifetime)
+      // After enough time, all projectiles should be inactive
+      for (let i = 0; i < 60; i++) {
+        system.update(1 / 60, closeEntities, addFloatingText, onDeath);
+      }
+
+      const activeCount = system.botProjectiles.filter(p => p.active).length;
+      // Some may still be active if recently fired, but most should have expired
+      expect(activeCount).toBeLessThanOrEqual(2);
     });
   });
 
@@ -287,6 +344,22 @@ describe('OrbitBotSystem', () => {
       const dy = system.bot.y - player.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
       expect(dist).toBeLessThan(100);
+    });
+
+    it('clears all projectiles and fire timer on reset', () => {
+      const enemy = makeEnemy(80, 0, 100);
+      const entities: GameEntity[] = [enemy];
+
+      // Let bot orbit and fire
+      for (let i = 0; i < 180; i++) {
+        system.update(1 / 60, entities, addFloatingText, onDeath);
+      }
+
+      system.reset();
+
+      expect(system.bot.fireTimer).toBe(0);
+      const activeCount = system.botProjectiles.filter(p => p.active).length;
+      expect(activeCount).toBe(0);
     });
   });
 });

--- a/src/systems/OrbitBotSystem.ts
+++ b/src/systems/OrbitBotSystem.ts
@@ -23,11 +23,23 @@ export interface OrbitBot {
   /** Accumulated damage for batched floating text */
   damageAccum: number;
   damageTextTimer: number;
+  /** Timer for projectile firing cadence */
+  fireTimer: number;
+}
+
+export interface BotProjectile {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  damage: number;
+  lifetime: number;
+  active: boolean;
 }
 
 // Orbit radii
 const PLAYER_ORBIT_RADIUS = 50;
-const ENEMY_ORBIT_RADIUS = 30;
+const ENEMY_ORBIT_RADIUS = 42;
 
 // Detection / leash
 const DETECTION_RANGE = 250;
@@ -44,17 +56,22 @@ const BOT_ACCEL = BOT_SPEED * BOT_FRICTION;
 const ORBIT_ARRIVAL_THRESHOLD = 15;
 const PLAYER_ORBIT_ARRIVAL = PLAYER_ORBIT_RADIUS + ORBIT_ARRIVAL_THRESHOLD;
 
-// Combat
-const DAMAGE_PER_SECOND = 4;
-const CONTACT_RANGE = 35;
-const CONTACT_RANGE_SQ = CONTACT_RANGE * CONTACT_RANGE;
+// Projectile combat
+const FIRE_INTERVAL = 0.5; // seconds between shots (~2 shots/sec)
+const PROJECTILE_SPEED = 200;
+const PROJECTILE_DAMAGE = 2;
+const PROJECTILE_LIFETIME = 0.5;
+const PROJECTILE_HIT_RANGE = 10;
+const PROJECTILE_HIT_RANGE_SQ = PROJECTILE_HIT_RANGE * PROJECTILE_HIT_RANGE;
 const DAMAGE_TEXT_INTERVAL = 0.5; // batch damage text every 0.5s
+const MAX_BOT_PROJECTILES = 8; // pool size (2 shots/sec * 0.5s lifetime = ~1 active, but allow headroom)
 
 export class OrbitBotSystem {
   static readonly PLAYER_ANGULAR_SPEED = 2;
-  static readonly ENEMY_ANGULAR_SPEED = 4;
+  static readonly ENEMY_ANGULAR_SPEED = 2.8;
 
   bot: OrbitBot;
+  botProjectiles: BotProjectile[];
   private player: Player;
 
   constructor(player: Player) {
@@ -69,7 +86,13 @@ export class OrbitBotSystem {
       targetEnemy: null,
       damageAccum: 0,
       damageTextTimer: 0,
+      fireTimer: 0,
     };
+    // Pre-allocate projectile pool
+    this.botProjectiles = [];
+    for (let i = 0; i < MAX_BOT_PROJECTILES; i++) {
+      this.botProjectiles.push({ x: 0, y: 0, vx: 0, vy: 0, damage: 0, lifetime: 0, active: false });
+    }
   }
 
   reset(): void {
@@ -82,6 +105,11 @@ export class OrbitBotSystem {
     this.bot.targetEnemy = null;
     this.bot.damageAccum = 0;
     this.bot.damageTextTimer = 0;
+    this.bot.fireTimer = 0;
+    // Deactivate all projectiles
+    for (let i = 0; i < this.botProjectiles.length; i++) {
+      this.botProjectiles[i].active = false;
+    }
   }
 
   update(
@@ -127,7 +155,7 @@ export class OrbitBotSystem {
           break;
         }
         this.orbitAround(dt, bot.targetEnemy.x, bot.targetEnemy.y, ENEMY_ORBIT_RADIUS, OrbitBotSystem.ENEMY_ANGULAR_SPEED);
-        this.dealDamage(dt, addFloatingText, onDeath);
+        this.fireProjectile(dt);
         break;
 
       case OrbitBotState.Returning:
@@ -141,6 +169,9 @@ export class OrbitBotSystem {
     bot.vy *= decay;
     bot.x += bot.vx * dt;
     bot.y += bot.vy * dt;
+
+    // Update projectiles
+    this.updateProjectiles(dt, addFloatingText, onDeath);
   }
 
   private findTarget(entities: GameEntity[]): void {
@@ -239,47 +270,104 @@ export class OrbitBotSystem {
     return dx * dx + dy * dy > LEASH_DISTANCE_SQ;
   }
 
-  private dealDamage(
+  private fireProjectile(dt: number): void {
+    const bot = this.bot;
+    const target = bot.targetEnemy;
+    if (!target || !target.active) return;
+
+    bot.fireTimer -= dt;
+    if (bot.fireTimer > 0) return;
+
+    bot.fireTimer = FIRE_INTERVAL;
+
+    // Find an inactive projectile slot
+    let slot: BotProjectile | null = null;
+    for (let i = 0; i < this.botProjectiles.length; i++) {
+      if (!this.botProjectiles[i].active) {
+        slot = this.botProjectiles[i];
+        break;
+      }
+    }
+    if (!slot) return; // All slots full, skip this shot
+
+    // Compute direction from bot to enemy
+    const dx = target.x - bot.x;
+    const dy = target.y - bot.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < 1) return; // Too close, skip
+
+    const dirX = dx / dist;
+    const dirY = dy / dist;
+
+    // Initialize projectile
+    slot.x = bot.x;
+    slot.y = bot.y;
+    slot.vx = dirX * PROJECTILE_SPEED;
+    slot.vy = dirY * PROJECTILE_SPEED;
+    slot.damage = PROJECTILE_DAMAGE;
+    slot.lifetime = PROJECTILE_LIFETIME;
+    slot.active = true;
+  }
+
+  private updateProjectiles(
     dt: number,
     addFloatingText: FloatingTextCallback,
     onDeath: DeathCallback,
   ): void {
     const bot = this.bot;
     const target = bot.targetEnemy;
-    if (!target || !target.active) return;
 
-    const dx = bot.x - target.x;
-    const dy = bot.y - target.y;
-    const distSq = dx * dx + dy * dy;
+    for (let i = 0; i < this.botProjectiles.length; i++) {
+      const p = this.botProjectiles[i];
+      if (!p.active) continue;
 
-    if (distSq < CONTACT_RANGE_SQ) {
-      const dmg = DAMAGE_PER_SECOND * dt;
-      target.health -= dmg;
-      target.aggro = true;
+      // Move
+      p.x += p.vx * dt;
+      p.y += p.vy * dt;
 
-      // Batch floating text
-      bot.damageAccum += dmg;
-      bot.damageTextTimer -= dt;
-      if (bot.damageTextTimer <= 0) {
-        const shown = Math.round(bot.damageAccum);
-        if (shown > 0) {
-          addFloatingText(`-${shown}`, target.x, target.y, getTheme().events.damage);
-        }
-        bot.damageAccum = 0;
-        bot.damageTextTimer = DAMAGE_TEXT_INTERVAL;
+      // Decrement lifetime
+      p.lifetime -= dt;
+      if (p.lifetime <= 0) {
+        p.active = false;
+        continue;
       }
 
-      if (target.health <= 0 && target.active) {
-        target.active = false;
-        const deathColor = target.subtype === 'ranged' ? getTheme().entities.enemyRanged : getTheme().entities.enemy;
-        onDeath(target.x, target.y, bot.x, bot.y, deathColor);
-        this.player.addEnergy(target.energyDrop);
-        this.player.kills++;
-        this.player.score += 50;
-        addFloatingText('+50', target.x, target.y - 15, getTheme().entities.salvage);
+      // Check collision with target enemy
+      if (target && target.active) {
+        const dx = p.x - target.x;
+        const dy = p.y - target.y;
+        if (dx * dx + dy * dy < PROJECTILE_HIT_RANGE_SQ) {
+          // Hit!
+          target.health -= p.damage;
+          target.aggro = true;
+          p.active = false;
 
-        bot.targetEnemy = null;
-        bot.state = OrbitBotState.Returning;
+          // Batch floating text
+          bot.damageAccum += p.damage;
+          bot.damageTextTimer -= dt;
+          if (bot.damageTextTimer <= 0) {
+            const shown = Math.round(bot.damageAccum);
+            if (shown > 0) {
+              addFloatingText(`-${shown}`, target.x, target.y, getTheme().events.damage);
+            }
+            bot.damageAccum = 0;
+            bot.damageTextTimer = DAMAGE_TEXT_INTERVAL;
+          }
+
+          // Check kill
+          if (target.health <= 0 && target.active) {
+            target.active = false;
+            const deathColor = target.subtype === 'ranged' ? getTheme().entities.enemyRanged : getTheme().entities.enemy;
+            onDeath(target.x, target.y, bot.x, bot.y, deathColor);
+            this.player.addEnergy(target.energyDrop);
+            this.player.kills++;
+            this.player.score += 50;
+            addFloatingText('+50', target.x, target.y - 15, getTheme().entities.salvage);
+
+            bot.targetEnemy = null;
+            bot.state = OrbitBotState.Returning;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Replaces the OrbitBot's contact-based damage system with projectile attacks and tunes orbit parameters for better visual clarity. The bot now fires small cyan projectiles at its target while orbiting, maintaining the same ~4 DPS output but with more visible and satisfying combat feedback. Enemy orbit is wider (42px) and slower (2.8 rad/s) so the bot's movement is more readable.

## Changes

The core change is in `OrbitBotSystem.ts`, which replaces the continuous contact damage model with a projectile-based one. The bot now maintains a `fireTimer` that fires every 0.5s while in `OrbitingEnemy` state, creating projectiles aimed at the target enemy. Projectiles are stored in a pre-allocated pool of 8 slots (marked active/inactive to avoid hot-path allocations) and travel at 200px/s with a 0.5s lifetime. Each hit deals 2 damage within a 10px collision radius.

Orbit parameters are tuned: `ENEMY_ORBIT_RADIUS` goes from 30 to 42px and `ENEMY_ANGULAR_SPEED` from 4.0 to 2.8 rad/s. Player orbit stays at 50px / 2 rad/s.

In `main.ts`, bot projectiles are rendered as small cyan dots (2px radius) with a subtle glow, batched into a single draw call with one `save()`/`restore()` to minimize canvas state changes.

Tests are updated to verify projectile-based damage dealing, kill tracking, floating text generation, lifetime expiry, and reset behavior.

## PRDs Completed
1. **prd-001** [frontend] — OrbitBot projectile attacks and orbit tuning

## Test Coverage
- 20 tests covering orbit behavior, target detection, projectile combat, leash/return, velocity movement, and reset
- Full suite: 414 tests passing, TypeScript clean

## Quality Gates
- [x] Tests: 414/414 passing
- [x] TypeScript: clean
- [x] Lint: n/a (no linter configured)

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2