### PR TITLE
Add home base direction arrow on radar ping circle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1026,7 +1026,7 @@ const loop = new GameLoop({
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     // Radar (drawn without rotation — rings/crosshair are fixed)
-    radar.render(ctx, cx, cy);
+    radar.render(ctx, cx, cy, player.x, player.y, player.heading);
 
     // Rotated world layer — full screen visibility, no circular clip
     ctx.save();

--- a/src/radar/RadarDisplay.test.ts
+++ b/src/radar/RadarDisplay.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { RadarDisplay, DEFAULT_RADAR_CONFIG } from './RadarDisplay';
+import { RadarDisplay, DEFAULT_RADAR_CONFIG, computeHomeArrowAngle, shouldShowHomeArrow } from './RadarDisplay';
+
+/** Normalize angle to [0, 2PI) for comparison */
+function normalizeAngle(a: number): number {
+  const TWO_PI = Math.PI * 2;
+  return ((a % TWO_PI) + TWO_PI) % TWO_PI;
+}
 
 describe('RadarDisplay', () => {
   it('initializes with default config', () => {
@@ -29,5 +35,69 @@ describe('RadarDisplay', () => {
     });
     // No error thrown — ping state is stored for rendering
     expect(radar.getRadius()).toBe(340);
+  });
+});
+
+describe('computeHomeArrowAngle', () => {
+  it('computes angle toward origin from a position to the right', () => {
+    // Player at (500, 0), heading 0
+    const angle = computeHomeArrowAngle(500, 0, 0);
+    // atan2(-0, -500) can be PI or -PI depending on -0 semantics
+    // Result minus heading(0) minus PI/2 — should normalize to PI/2 or 3PI/2
+    // The key property: the arrow should point left on screen (toward home)
+    const normalized = normalizeAngle(angle);
+    // -0 makes atan2 return -PI, so -PI - 0 - PI/2 = -3PI/2 → normalized = PI/2
+    expect(normalized).toBeCloseTo(normalizeAngle(-3 * Math.PI / 2), 5);
+  });
+
+  it('computes angle toward origin from a position above (negative y)', () => {
+    // Player at (0, -500), heading 0 — home is directly below
+    const angle = computeHomeArrowAngle(0, -500, 0);
+    // atan2(500, 0) = PI/2, minus 0 minus PI/2 = 0
+    expect(normalizeAngle(angle)).toBeCloseTo(0, 5);
+  });
+
+  it('accounts for player heading rotation', () => {
+    // Player at (500, 0), heading PI/2
+    const angle = computeHomeArrowAngle(500, 0, Math.PI / 2);
+    // Should differ from heading=0 by exactly PI/2
+    const angleNoHeading = computeHomeArrowAngle(500, 0, 0);
+    const diff = normalizeAngle(angleNoHeading - angle);
+    expect(diff).toBeCloseTo(Math.PI / 2, 5);
+  });
+
+  it('rotates proportionally with heading changes', () => {
+    // When heading changes by delta, the arrow angle changes by -delta
+    const base = computeHomeArrowAngle(300, 400, 0);
+    const rotated = computeHomeArrowAngle(300, 400, 1.0);
+    expect(normalizeAngle(base - rotated)).toBeCloseTo(1.0, 5);
+  });
+});
+
+describe('shouldShowHomeArrow', () => {
+  it('returns false when player is at the origin', () => {
+    expect(shouldShowHomeArrow(0, 0)).toBe(false);
+  });
+
+  it('returns false when player is within 200px of origin', () => {
+    expect(shouldShowHomeArrow(100, 100)).toBe(false); // ~141px
+    expect(shouldShowHomeArrow(141, 0)).toBe(false);
+    expect(shouldShowHomeArrow(0, 199)).toBe(false);
+  });
+
+  it('returns true when player is exactly at 200px from origin', () => {
+    // 200px is the boundary — at exactly 200 we hide (> 200 shows)
+    expect(shouldShowHomeArrow(200, 0)).toBe(false);
+  });
+
+  it('returns true when player is beyond 200px from origin', () => {
+    expect(shouldShowHomeArrow(201, 0)).toBe(true);
+    expect(shouldShowHomeArrow(0, 300)).toBe(true);
+    expect(shouldShowHomeArrow(500, 500)).toBe(true);
+  });
+
+  it('handles negative coordinates', () => {
+    expect(shouldShowHomeArrow(-300, -400)).toBe(true); // 500px
+    expect(shouldShowHomeArrow(-100, -100)).toBe(false); // ~141px
   });
 });

--- a/src/radar/RadarDisplay.ts
+++ b/src/radar/RadarDisplay.ts
@@ -1,6 +1,23 @@
 import { PingState } from '../systems/PingSystem';
 import { getTheme } from '../themes/theme';
 
+/** Distance threshold — hide the home arrow when player is this close to origin */
+const HOME_ARROW_MIN_DISTANCE = 200;
+
+/**
+ * Compute the screen-space angle for the home base direction arrow.
+ * RadarDisplay renders before the world rotation transform, so we must
+ * account for the player heading and the PI/2 offset applied in main.ts.
+ */
+export function computeHomeArrowAngle(playerX: number, playerY: number, playerHeading: number): number {
+  return Math.atan2(-playerY, -playerX) - playerHeading - Math.PI / 2;
+}
+
+/** Returns true when the player is far enough from origin to show the arrow */
+export function shouldShowHomeArrow(playerX: number, playerY: number): boolean {
+  return playerX * playerX + playerY * playerY > HOME_ARROW_MIN_DISTANCE * HOME_ARROW_MIN_DISTANCE;
+}
+
 export interface RadarConfig {
   /** Radar radius in pixels */
   radius: number;
@@ -41,7 +58,14 @@ export class RadarDisplay {
     this.pingState = state;
   }
 
-  render(ctx: CanvasRenderingContext2D, centerX: number, centerY: number): void {
+  render(
+    ctx: CanvasRenderingContext2D,
+    centerX: number,
+    centerY: number,
+    playerX = 0,
+    playerY = 0,
+    playerHeading = 0,
+  ): void {
     const { radius } = this.config;
     const theme = getTheme();
     const color = theme.radar.primary;
@@ -92,6 +116,28 @@ export class RadarDisplay {
     ctx.lineWidth = 2;
     ctx.stroke();
     ctx.restore();
+
+    // Home base direction arrow — gold chevron on outer ring pointing toward origin
+    if (shouldShowHomeArrow(playerX, playerY)) {
+      const arrowAngle = computeHomeArrowAngle(playerX, playerY, playerHeading);
+      const arrowX = centerX + Math.cos(arrowAngle) * radius;
+      const arrowY = centerY + Math.sin(arrowAngle) * radius;
+      const arrowSize = 8;
+
+      ctx.save();
+      ctx.translate(arrowX, arrowY);
+      ctx.rotate(arrowAngle); // rotate so the chevron points outward from center
+      ctx.globalAlpha = 0.7;
+      ctx.fillStyle = '#ffaa00';
+      ctx.beginPath();
+      // Triangle pointing outward (right along local x-axis after rotation)
+      ctx.moveTo(arrowSize, 0);
+      ctx.lineTo(-arrowSize * 0.5, -arrowSize * 0.5);
+      ctx.lineTo(-arrowSize * 0.5, arrowSize * 0.5);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
 
     // Center dot
     ctx.beginPath();


### PR DESCRIPTION
## Summary

Adds a gold chevron indicator on the radar display's outer ring that always points toward the home base (world origin 0,0). The arrow helps players navigate back to base during gameplay. It appears when the player is more than 200px from origin and rotates correctly as the player moves and turns.

This addresses GitHub Issue #69 item 4.

## Changes

The implementation touches two files, with the core logic extracted as pure functions for testability:

**`src/radar/RadarDisplay.ts`** — Added `computeHomeArrowAngle()` and `shouldShowHomeArrow()` as exported pure functions. The angle computation accounts for the world rotation transform that happens after radar rendering (`-player.heading - PI/2`). Updated `render()` to accept `playerX`, `playerY`, `playerHeading` parameters (with default values for backward compatibility). The arrow draws as a gold (#ffaa00, 0.7 alpha) triangle/chevron on the outer ring circumference, positioned between the outer ring and center dot. No shadowBlur is used.

**`src/main.ts`** — Updated the `radar.render()` call to pass `player.x`, `player.y`, `player.heading`.

**`src/radar/RadarDisplay.test.ts`** — Added 9 new tests covering angle computation (4 tests verifying directional correctness and heading rotation proportionality) and visibility threshold (5 tests covering origin, near, boundary, far, and negative coordinates).

## PRDs Completed

1. **prd-001** (frontend): Home base direction arrow on radar display

## Test Coverage

- 9 new tests for angle math and visibility logic
- All 419 tests pass
- TypeScript strict mode passes

## Quality Gates

- [x] Tests: 419/419 passing
- [x] TypeScript: strict mode, no errors
- [x] Code review: PASS
- [x] Performance: no shadowBlur, squared distance comparison (no sqrt), no allocations in hot path

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2