### PR TITLE
feat: expandable minimap with smooth animation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -228,6 +228,7 @@ function init() {
   deathParticles = new DeathParticles(200);
   towRopeSystem = new TowRopeSystem();
   minimap = new Minimap();
+  minimap.initBounds(canvas.width, canvas.height);
   keyRemapScreen = new KeyRemapScreen();
   keyRemapScreen.addExtraBinding({
     id: 'upgrades',
@@ -463,6 +464,10 @@ window.addEventListener('keydown', (e) => {
     helpScreen.toggle();
     return;
   }
+  if ((e.key === 'm' || e.key === 'M') && (isActiveGameplay(gameState) || gameState === 'base_mode')) {
+    minimap.toggle();
+    return;
+  }
 
   // Ability keybinds — only if abilities are enabled
   if (!isActiveGameplay(gameState) || keyRemapScreen.isVisible()) return;
@@ -510,12 +515,35 @@ window.addEventListener('keydown', (e) => {
   }
 });
 
+// Minimap click handler: click inside to expand, click outside to collapse
+canvas.addEventListener('click', (e) => {
+  if (!isActiveGameplay(gameState) && gameState !== 'base_mode') return;
+  const rect = canvas.getBoundingClientRect();
+  const mx = (e.clientX - rect.left) * (canvas.width / rect.width);
+  const my = (e.clientY - rect.top) * (canvas.height / rect.height);
+
+  if (minimap.isExpanded()) {
+    // Click outside the expanded minimap to collapse
+    if (!minimap.hitTest(mx, my)) {
+      minimap.collapse();
+    }
+  } else {
+    // Click inside the collapsed minimap to expand
+    if (minimap.hitTest(mx, my)) {
+      minimap.expand();
+    }
+  }
+});
+
 // Start on main menu
 showMainMenu();
 
 const loop = new GameLoop({
   update(dt) {
     if (!isActiveGameplay(gameState)) return;
+
+    // Minimap animation
+    minimap.update(dt);
 
     // Run timer countdown — only during timed runs
     if (gameState === 'run_active' && runTimer >= 0) {

--- a/src/ui/Minimap.test.ts
+++ b/src/ui/Minimap.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Minimap } from './Minimap';
 import { Player } from '../entities/Player';
-import { createAlly, createDropoff, createEnemy, createResource, GameEntity } from '../entities/Entity';
+import { createAlly, createDropoff, createEnemy, createResource, createSalvage, GameEntity } from '../entities/Entity';
 
 describe('Minimap', () => {
   let minimap: Minimap;
@@ -10,7 +10,7 @@ describe('Minimap', () => {
     minimap = new Minimap();
   });
 
-  describe('getVisibleEntities', () => {
+  describe('getVisibleEntities (collapsed)', () => {
     it('includes dropoff entities', () => {
       const dropoff = createDropoff(100, 200);
       const result = minimap.getVisibleEntities([dropoff]);
@@ -49,37 +49,130 @@ describe('Minimap', () => {
         createResource(0, 0),
         createDropoff(100, 100),
         createAlly(200, 200, 'beacon'),
-        createEnemy(300, 300, 'brute'),  // invisible by default
+        createEnemy(300, 300, 'brute'),
       ];
       const result = minimap.getVisibleEntities(entities);
       expect(result).toHaveLength(1); // dropoff only
     });
   });
 
+  describe('getVisibleEntities (expanded)', () => {
+    beforeEach(() => {
+      // Force expanded state
+      minimap.expand();
+      // Advance animation past 0.5 threshold
+      minimap.update(0.2);
+    });
+
+    it('includes all active entity types when expanded', () => {
+      const entities: GameEntity[] = [
+        createResource(0, 0),
+        createDropoff(100, 100),
+        createAlly(200, 200, 'beacon'),
+        createEnemy(300, 300, 'brute'),
+        createSalvage(400, 400),
+      ];
+      const result = minimap.getVisibleEntities(entities);
+      expect(result).toHaveLength(5);
+    });
+
+    it('still excludes inactive entities when expanded', () => {
+      const enemy = createEnemy(0, 0, 'scout');
+      enemy.active = false;
+      const result = minimap.getVisibleEntities([enemy]);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('update and animation', () => {
+    it('starts fully collapsed', () => {
+      expect(minimap.animProgress).toBe(0);
+      expect(minimap.isExpanded()).toBe(false);
+    });
+
+    it('advances animProgress toward 1 when expanded', () => {
+      minimap.expand();
+      minimap.update(0.1); // 5 * 0.1 = 0.5
+      expect(minimap.animProgress).toBeCloseTo(0.5);
+    });
+
+    it('reaches fully expanded after 0.2s', () => {
+      minimap.expand();
+      minimap.update(0.2); // 5 * 0.2 = 1.0
+      expect(minimap.animProgress).toBe(1);
+      expect(minimap.isExpanded()).toBe(true);
+    });
+
+    it('collapses back after toggle', () => {
+      minimap.expand();
+      minimap.update(0.2); // fully expanded
+      minimap.collapse();
+      minimap.update(0.2); // fully collapsed
+      expect(minimap.animProgress).toBe(0);
+      expect(minimap.isExpanded()).toBe(false);
+    });
+
+    it('toggle flips the target', () => {
+      minimap.toggle();
+      minimap.update(0.2);
+      expect(minimap.isExpanded()).toBe(true);
+
+      minimap.toggle();
+      minimap.update(0.2);
+      expect(minimap.isExpanded()).toBe(false);
+    });
+
+    it('does not overshoot 1 or undershoot 0', () => {
+      minimap.expand();
+      minimap.update(10); // way more than needed
+      expect(minimap.animProgress).toBe(1);
+
+      minimap.collapse();
+      minimap.update(10);
+      expect(minimap.animProgress).toBe(0);
+    });
+  });
+
+  describe('hitTest', () => {
+    it('returns true for point inside collapsed minimap', () => {
+      minimap.initBounds(800, 600);
+
+      // Collapsed minimap: x=20, y=600-20-160=420, size=160
+      expect(minimap.hitTest(100, 500)).toBe(true);
+    });
+
+    it('returns false for point outside collapsed minimap', () => {
+      minimap.initBounds(800, 600);
+
+      expect(minimap.hitTest(400, 300)).toBe(false);
+    });
+  });
+
   describe('worldToMinimap', () => {
     it('maps player position to minimap center', () => {
       const player = new Player(500, 500);
+      minimap.initBounds(800, 600);
+
       const pos = minimap.worldToMinimap(500, 500, player, 800, 600);
-      // Should be at the center of the minimap area
       expect(pos.x).toBeCloseTo(pos.centerX);
       expect(pos.y).toBeCloseTo(pos.centerY);
     });
 
     it('maps offset entities to offset positions on minimap', () => {
       const player = new Player(500, 500);
-      // Entity 1000px to the right of player
+      minimap.initBounds(800, 600);
+
       const pos = minimap.worldToMinimap(1500, 500, player, 800, 600);
-      // Should be to the right of center
       expect(pos.x).toBeGreaterThan(pos.centerX);
       expect(pos.y).toBeCloseTo(pos.centerY);
     });
 
     it('clamps entities beyond world radius to minimap bounds', () => {
       const player = new Player(0, 0);
-      // Entity very far away (beyond 2000px world radius)
+      minimap.initBounds(800, 600);
+
       const pos = minimap.worldToMinimap(5000, 0, player, 800, 600);
-      // x should be clamped within minimap bounds
-      const maxOffset = minimap.getSize() / 2;
+      const maxOffset = minimap.getCurrentSize() / 2;
       expect(pos.x - pos.centerX).toBeLessThanOrEqual(maxOffset);
     });
   });
@@ -98,6 +191,11 @@ describe('Minimap', () => {
     it('returns red for enemy entities', () => {
       const enemy = createEnemy(0, 0, 'scout');
       expect(minimap.getEntityColor(enemy)).toBe('#ff4141');
+    });
+
+    it('returns green for resource entities', () => {
+      const resource = createResource(0, 0);
+      expect(minimap.getEntityColor(resource)).toBe('#00ff41');
     });
   });
 });

--- a/src/ui/Minimap.ts
+++ b/src/ui/Minimap.ts
@@ -2,22 +2,129 @@ import { Player } from '../entities/Player';
 import { GameEntity, HomeBase } from '../entities/Entity';
 import { getTheme } from '../themes/theme';
 
-const SIZE = 160;
+// Collapsed constants
+const COLLAPSED_SIZE = 160;
+const COLLAPSED_WORLD_RADIUS = 2000;
+const COLLAPSED_DOT_RADIUS = 3;
+const EXPANDED_DOT_RADIUS = 5;
+const EXPANDED_WORLD_RADIUS = 4000;
 const PADDING = 20;
-const WORLD_RADIUS = 2000;
-const DOT_RADIUS = 3;
 const PLAYER_DOT_RADIUS = 4;
 const HEADING_LINE_LENGTH = 12;
+const ANIM_RATE = 5; // 1/0.2s = 5 per second
+const DISTANCE_RING_INTERVAL = 500; // world-space px
+
+function easeInOutCubic(t: number): number {
+  return t < 0.5
+    ? 4 * t * t * t
+    : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/** Label for entity type shown in expanded view */
+function entityLabel(type: string): string {
+  switch (type) {
+    case 'resource': return 'RES';
+    case 'enemy': return 'ENEMY';
+    case 'ally': return 'ALLY';
+    case 'salvage': return 'SALVAGE';
+    case 'dropoff': return 'DROP';
+    default: return '';
+  }
+}
 
 
 export class Minimap {
+  private _targetExpanded = false;
+  private _animProgress = 0; // 0 = collapsed, 1 = expanded
+  // Cached interpolated values (reused each frame, no alloc)
+  private _currentSize = COLLAPSED_SIZE;
+  private _currentX = PADDING;
+  private _currentY = 0; // Set properly on first render
+  private _currentWorldRadius = COLLAPSED_WORLD_RADIUS;
+  private _currentDotRadius = COLLAPSED_DOT_RADIUS;
+  private _boundsInitialized = false;
+
   getSize(): number {
-    return SIZE;
+    return COLLAPSED_SIZE;
+  }
+
+  /** Current animated size (for hit-testing from outside) */
+  getCurrentSize(): number {
+    return this._currentSize;
+  }
+
+  /** Current animated top-left X */
+  getCurrentX(): number {
+    return this._currentX;
+  }
+
+  /** Current animated top-left Y */
+  getCurrentY(): number {
+    return this._currentY;
+  }
+
+  get animProgress(): number {
+    return this._animProgress;
+  }
+
+  isExpanded(): boolean {
+    return this._animProgress > 0.5;
+  }
+
+  toggle(): void {
+    this._targetExpanded = !this._targetExpanded;
+  }
+
+  collapse(): void {
+    this._targetExpanded = false;
+  }
+
+  expand(): void {
+    this._targetExpanded = true;
+  }
+
+  /** Initialize cached bounds without rendering (useful for hit-testing before first render) */
+  initBounds(canvasWidth: number, canvasHeight: number): void {
+    if (!this._boundsInitialized) {
+      this._currentX = PADDING;
+      this._currentY = canvasHeight - PADDING - COLLAPSED_SIZE;
+      this._boundsInitialized = true;
+    }
+  }
+
+  /** Check if a screen-space point is inside the current minimap bounds */
+  hitTest(screenX: number, screenY: number): boolean {
+    return (
+      screenX >= this._currentX &&
+      screenX <= this._currentX + this._currentSize &&
+      screenY >= this._currentY &&
+      screenY <= this._currentY + this._currentSize
+    );
+  }
+
+  update(dt: number): void {
+    const target = this._targetExpanded ? 1 : 0;
+    if (this._animProgress === target) return;
+
+    if (this._animProgress < target) {
+      this._animProgress = Math.min(target, this._animProgress + ANIM_RATE * dt);
+    } else {
+      this._animProgress = Math.max(target, this._animProgress - ANIM_RATE * dt);
+    }
   }
 
   getVisibleEntities(entities: GameEntity[]): GameEntity[] {
+    const expanded = this._animProgress > 0.5;
     return entities.filter((e) => {
       if (!e.active) return false;
+      if (expanded) {
+        // Show all major entity types when expanded
+        return e.type === 'dropoff' || e.type === 'resource' || e.type === 'enemy' || e.type === 'ally' || e.type === 'salvage';
+      }
       return e.type === 'dropoff';
     });
   }
@@ -28,6 +135,7 @@ export class Minimap {
       : entity.type === 'ally' ? e.ally
       : entity.type === 'enemy' ? e.enemy
       : entity.type === 'salvage' ? e.salvage
+      : entity.type === 'resource' ? e.resource
       : '#ffffff';
   }
 
@@ -38,20 +146,21 @@ export class Minimap {
     canvasWidth: number,
     canvasHeight: number,
   ): { x: number; y: number; centerX: number; centerY: number } {
-    const centerX = PADDING + SIZE / 2;
-    const centerY = canvasHeight - PADDING - SIZE / 2;
+    const size = this._currentSize;
+    const worldRadius = this._currentWorldRadius;
+    const centerX = this._currentX + size / 2;
+    const centerY = this._currentY + size / 2;
 
     const dx = worldX - player.x;
     const dy = worldY - player.y;
 
-    // Clamp to world radius
     const dist = Math.sqrt(dx * dx + dy * dy);
-    const scale = SIZE / 2 / WORLD_RADIUS;
+    const scale = size / 2 / worldRadius;
     let mx: number, my: number;
 
-    if (dist > WORLD_RADIUS) {
-      const clampedDx = (dx / dist) * WORLD_RADIUS;
-      const clampedDy = (dy / dist) * WORLD_RADIUS;
+    if (dist > worldRadius) {
+      const clampedDx = (dx / dist) * worldRadius;
+      const clampedDy = (dy / dist) * worldRadius;
       mx = centerX + clampedDx * scale;
       my = centerY + clampedDy * scale;
     } else {
@@ -70,37 +179,78 @@ export class Minimap {
     canvasHeight: number,
     homeBase?: HomeBase,
   ): void {
-    const x = PADDING;
-    const y = canvasHeight - PADDING - SIZE;
+    const t = easeInOutCubic(this._animProgress);
+    const expanded = this._animProgress > 0.5;
+
+    // Compute interpolated values
+    const expandedSize = Math.min(canvasWidth, canvasHeight) * 0.8;
+    const size = lerp(COLLAPSED_SIZE, expandedSize, t);
+    const worldRadius = lerp(COLLAPSED_WORLD_RADIUS, EXPANDED_WORLD_RADIUS, t);
+    const dotRadius = lerp(COLLAPSED_DOT_RADIUS, EXPANDED_DOT_RADIUS, t);
+
+    // Position: collapsed = bottom-left, expanded = centered
+    const collapsedX = PADDING;
+    const collapsedY = canvasHeight - PADDING - COLLAPSED_SIZE;
+    const expandedX = (canvasWidth - expandedSize) / 2;
+    const expandedY = (canvasHeight - expandedSize) / 2;
+    const x = lerp(collapsedX, expandedX, t);
+    const y = lerp(collapsedY, expandedY, t);
+
+    // Cache for hit-testing and worldToMinimap
+    this._currentSize = size;
+    this._currentX = x;
+    this._currentY = y;
+    this._currentWorldRadius = worldRadius;
+    this._currentDotRadius = dotRadius;
 
     const theme = getTheme();
+
+    // Dark overlay behind expanded map
+    if (this._animProgress > 0) {
+      ctx.save();
+      ctx.fillStyle = 'rgba(0, 0, 0, ' + (0.6 * t) + ')';
+      ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+      ctx.restore();
+    }
 
     ctx.save();
 
     // Background
     ctx.fillStyle = theme.ui.panelBackground;
-    ctx.fillRect(x, y, SIZE, SIZE);
+    ctx.fillRect(x, y, size, size);
 
     // Border
     ctx.strokeStyle = theme.ui.borderDim;
     ctx.globalAlpha = 0.3;
     ctx.lineWidth = 1;
-    ctx.strokeRect(x, y, SIZE, SIZE);
+    ctx.strokeRect(x, y, size, size);
     ctx.globalAlpha = 1;
 
     // Clip to minimap area
     ctx.beginPath();
-    ctx.rect(x, y, SIZE, SIZE);
+    ctx.rect(x, y, size, size);
     ctx.clip();
 
-    const centerX = x + SIZE / 2;
-    const centerY = y + SIZE / 2;
+    const centerX = x + size / 2;
+    const centerY = y + size / 2;
+
+    // Distance rings (expanded only)
+    if (expanded) {
+      const scale = size / 2 / worldRadius;
+      ctx.strokeStyle = 'rgba(255, 255, 255, 0.1)';
+      ctx.lineWidth = 1;
+      for (let r = DISTANCE_RING_INTERVAL; r <= worldRadius; r += DISTANCE_RING_INTERVAL) {
+        const ringRadius = r * scale;
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, ringRadius, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    }
 
     // Home base marker
     if (homeBase) {
       const basePos = this.worldToMinimap(homeBase.x, homeBase.y, player, canvasWidth, canvasHeight);
-      // Base radius ring
-      const scale = SIZE / 2 / WORLD_RADIUS;
+      const scale = size / 2 / worldRadius;
       const baseRadiusOnMap = homeBase.radius * scale;
       ctx.beginPath();
       ctx.arc(basePos.x, basePos.y, Math.max(baseRadiusOnMap, 3), 0, Math.PI * 2);
@@ -112,6 +262,14 @@ export class Minimap {
       ctx.arc(basePos.x, basePos.y, 2, 0, Math.PI * 2);
       ctx.fillStyle = '#64dcff';
       ctx.fill();
+
+      // Home base label (expanded only)
+      if (expanded) {
+        ctx.font = '10px monospace';
+        ctx.fillStyle = '#64dcff';
+        ctx.textAlign = 'center';
+        ctx.fillText('HOME', basePos.x, basePos.y - 6);
+      }
     }
 
     // Entity dots
@@ -119,9 +277,19 @@ export class Minimap {
     for (const entity of visible) {
       const pos = this.worldToMinimap(entity.x, entity.y, player, canvasWidth, canvasHeight);
       ctx.beginPath();
-      ctx.arc(pos.x, pos.y, DOT_RADIUS, 0, Math.PI * 2);
+      ctx.arc(pos.x, pos.y, dotRadius, 0, Math.PI * 2);
       ctx.fillStyle = this.getEntityColor(entity);
       ctx.fill();
+
+      // Entity labels (expanded only)
+      if (expanded) {
+        const label = entityLabel(entity.type);
+        if (label) {
+          ctx.font = '8px monospace';
+          ctx.textAlign = 'left';
+          ctx.fillText(label, pos.x + dotRadius + 2, pos.y + 3);
+        }
+      }
     }
 
     // Player dot (primary, center)


### PR DESCRIPTION
## Summary

Transforms the minimap into an expandable map that smoothly animates between its small bottom-left corner view and a near-fullscreen detailed view. Press M or click the minimap to expand; press M again or click outside to collapse. The expanded view shows all entity types (resources, enemies, allies, salvage, dropoffs) with labels, distance rings at 500px intervals, and a labeled home base marker.

## Changes

The Minimap class gains animation state (`animProgress`, `targetExpanded`) and an `update(dt)` method that drives a 0.2s easeInOutCubic transition. During animation, all visual properties are interpolated: position (bottom-left to screen center), size (160px to 80% of viewport), world radius (2000px to 4000px), and dot radius (3px to 5px). A semi-transparent dark overlay scales with animation progress behind the expanded map.

In `main.ts`, the M key handler is added alongside existing key handlers (H, K, E), a canvas click listener handles expand/collapse by hit-testing minimap bounds, and `minimap.update(dt)` is called each frame. The collapsed view remains identical to the previous behavior.

## PRDs Completed

1. **prd-001** (frontend): Minimap expansion state, animation, toggle, expanded entity visibility
2. **prd-002** (frontend): Interpolated rendering — position, size, worldRadius, dotRadius, overlay, distance rings, labels
3. **prd-003** (frontend): M key handler, click-to-expand/collapse, main.ts update integration

## Test Coverage

- 23 tests covering: animation lifecycle (start, advance, complete, collapse, toggle, no overshoot), expanded entity visibility (all types shown vs dropoff-only), hit testing, world-to-minimap coordinate mapping, entity colors
- Full suite: 421 tests passing

## Quality Gates

- TypeScript: clean
- Tests: 421/421 passing
- Lint: n/a (not configured)

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2