### PR TITLE
feat: distance-based homing missile aim directness

### DIFF
--- a/src/systems/AbilitySystem.test.ts
+++ b/src/systems/AbilitySystem.test.ts
@@ -421,5 +421,132 @@ describe('AbilitySystem', () => {
       expect(enemy.health).toBeLessThan(80);
       expect(onShake).toHaveBeenCalledWith(7);
     });
+
+    describe('distance-based aim directness', () => {
+      it('uses higher effective turn rate for close targets than far targets', () => {
+        // Measure turn per frame: record launch angle, advance one frame, measure angular change
+        // Use multiple trials and average to reduce randomness from launch spread
+
+        function measureAverageTurnRate(enemyDist: number, trials: number): number {
+          let totalTurn = 0;
+          for (let t = 0; t < trials; t++) {
+            const { system, player } = buildAbilitySystem();
+            player.x = 0;
+            player.y = 0;
+            player.heading = Math.PI / 2; // facing up, enemy is to the right
+            const enemy = createEnemy(enemyDist, 0, 'brute');
+            enemy.visible = true;
+            enemy.health = 80;
+
+            system.activate('homing_missile', [enemy], () => {});
+            const launchAngle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+
+            system.update(0.016, [enemy], () => {}); // One frame at 60Hz
+            const afterAngle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+            totalTurn += Math.abs(afterAngle - launchAngle);
+          }
+          return totalTurn / trials;
+        }
+
+        const closeTurn = measureAverageTurnRate(40, 20);
+        const farTurn = measureAverageTurnRate(300, 20);
+
+        // Close target should produce more turn per frame on average
+        expect(closeTurn).toBeGreaterThan(farTurn);
+      });
+
+      it('uses narrower launch spread for close targets', () => {
+        // Fire many missiles at a close target and check the spread is narrow
+        const launchAngles: number[] = [];
+        for (let i = 0; i < 50; i++) {
+          const { system, player } = buildAbilitySystem();
+          player.x = 0;
+          player.y = 0;
+          player.heading = 0; // facing right
+          const enemy = createEnemy(40, 0, 'scout'); // Very close
+          enemy.visible = true;
+          system.activate('homing_missile', [enemy], () => {});
+          const angle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+          launchAngles.push(angle);
+        }
+
+        // All angles should be within ±30° (±0.524 rad) of heading (0)
+        const maxSpread = Math.max(...launchAngles.map((a) => Math.abs(a)));
+        expect(maxSpread).toBeLessThan(Math.PI * 0.35); // ~63° — generous bound for ±30° random
+      });
+
+      it('uses wider launch spread for far targets', () => {
+        // Fire many missiles at a far target and verify wider spread
+        const launchAngles: number[] = [];
+        for (let i = 0; i < 50; i++) {
+          const { system, player } = buildAbilitySystem();
+          player.x = 0;
+          player.y = 0;
+          player.heading = 0; // facing right
+          const enemy = createEnemy(400, 0, 'scout'); // Far away
+          enemy.visible = true;
+          system.activate('homing_missile', [enemy], () => {});
+          const angle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+          launchAngles.push(angle);
+        }
+
+        // Should see angles with larger spread — at least some beyond ±30°
+        const maxSpread = Math.max(...launchAngles.map((a) => Math.abs(a)));
+        expect(maxSpread).toBeGreaterThan(Math.PI * 0.2); // At least ~36° spread seen
+      });
+
+      it('close-range missiles hit their target reliably', () => {
+        // Fire 10 missiles at a very close target — all should hit
+        let hits = 0;
+        for (let trial = 0; trial < 10; trial++) {
+          const { system, player } = buildAbilitySystem();
+          player.x = 0;
+          player.y = 0;
+          player.heading = 0;
+          const enemy = createEnemy(40, 0, 'brute');
+          enemy.visible = true;
+          enemy.health = 80;
+          const entities: GameEntity[] = [enemy];
+
+          system.activate('homing_missile', entities, () => {});
+          for (let i = 0; i < 80; i++) system.update(0.05, entities, () => {});
+          if (enemy.health < 80) hits++;
+        }
+        // All should hit at close range with direct aim
+        expect(hits).toBe(10);
+      });
+
+      it('smoothly interpolates turn rate — medium range gets intermediate value', () => {
+        // Measure average turn per frame at three distances
+        function measureAverageTurn(enemyDist: number, trials: number): number {
+          let totalTurn = 0;
+          for (let t = 0; t < trials; t++) {
+            const { system, player } = buildAbilitySystem();
+            player.x = 0;
+            player.y = 0;
+            player.heading = Math.PI / 2;
+            const enemy = createEnemy(enemyDist, 0, 'brute');
+            enemy.visible = true;
+            enemy.health = 80;
+
+            system.activate('homing_missile', [enemy], () => {});
+            const launchAngle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+
+            system.update(0.016, [enemy], () => {});
+            const afterAngle = Math.atan2(system.missiles[0].vy, system.missiles[0].vx);
+            totalTurn += Math.abs(afterAngle - launchAngle);
+          }
+          return totalTurn / trials;
+        }
+
+        const closeTurn = measureAverageTurn(40, 20);
+        const mediumTurn = measureAverageTurn(100, 20);
+        const farTurn = measureAverageTurn(300, 20);
+
+        // close > medium > far (smooth gradient)
+        expect(closeTurn).toBeGreaterThan(mediumTurn);
+        expect(mediumTurn).toBeGreaterThan(farTurn);
+      });
+    });
   });
 });

--- a/src/systems/AbilitySystem.ts
+++ b/src/systems/AbilitySystem.ts
@@ -215,16 +215,28 @@ export class AbilitySystem {
   }
 
   private spawnMissile(entities: GameEntity[]): void {
-    // Check if any visible enemies exist to target
-    const hasTarget = entities.some(
-      (e) => e.active && e.type === 'enemy' && e.visible,
-    );
+    // Find nearest visible enemy and its distance
+    let nearestDist = Infinity;
+    let hasTarget = false;
+    for (const entity of entities) {
+      if (!entity.active || entity.type !== 'enemy' || !entity.visible) continue;
+      hasTarget = true;
+      const dx = entity.x - this.player.x;
+      const dy = entity.y - this.player.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < nearestDist) nearestDist = dist;
+    }
 
-    // With a target: random spread for arcing trajectory
-    // Without: fire straight ahead from the ship
-    const launchSpread = hasTarget
-      ? (Math.random() - 0.5) * Math.PI * 1.2 // ±108° spread
-      : 0;
+    // Distance-scaled launch spread: close targets get narrow spread, far targets get wide spread
+    // ±30° (0.524 rad half-spread) at <80px, ±108° (1.885 rad half-spread) at >250px, smooth lerp between
+    let launchSpread = 0;
+    if (hasTarget) {
+      const closeSpread = Math.PI * (30 / 180);  // ±30° half-spread
+      const farSpread = Math.PI * 1.2 * 0.5;     // ±108° half-spread (PI*1.2 total / 2)
+      const spreadT = Math.min(1, Math.max(0, (nearestDist - 80) / (250 - 80)));
+      const halfSpread = closeSpread + (farSpread - closeSpread) * spreadT;
+      launchSpread = (Math.random() - 0.5) * 2 * halfSpread;
+    }
     const launchAngle = this.player.heading + launchSpread;
     const launchSpeed = hasTarget ? 60 : 220; // Full speed ahead if no target
 
@@ -236,7 +248,7 @@ export class AbilitySystem {
       speed: 220,
       damage: 5, // TODO: restore to 25 after testing
       lifetime: 4,
-      turnRate: 3.5, // radians/sec — slightly higher to compensate for random launch
+      turnRate: 3.5, // base turn rate — effective rate scaled by distance in updateMissiles
       active: true,
     });
   }
@@ -321,8 +333,17 @@ export class AbilitySystem {
         while (angleDiff > Math.PI) angleDiff -= Math.PI * 2;
         while (angleDiff < -Math.PI) angleDiff += Math.PI * 2;
 
-        // Clamp turn to turnRate * dt
-        const maxTurn = missile.turnRate * dt;
+        // Distance-scaled turn rate: close targets get much higher turn rate for direct shots
+        // effectiveTurnRate = baseTurnRate * max(1, closeRangeFactor / clamp(dist, minDist, maxDist))
+        // At 30px: 3.5 * (175/30) ≈ 20.4 rad/s (nearly instant aim)
+        // At 175px: 3.5 * (175/175) = 3.5 rad/s (standard)
+        // At 300px+: 3.5 * (175/300) ≈ 2.04 → clamped to 3.5 via max(1,...)
+        const dist = Math.sqrt(nearestDistSq);
+        const clampedDist = Math.min(300, Math.max(30, dist));
+        const effectiveTurnRate = missile.turnRate * Math.max(1, 175 / clampedDist);
+
+        // Clamp turn to effectiveTurnRate * dt
+        const maxTurn = effectiveTurnRate * dt;
         const turn = Math.max(-maxTurn, Math.min(maxTurn, angleDiff));
         newAngle = currentAngle + turn;
       }


### PR DESCRIPTION
## Summary

Scale missile launch spread and turn rate based on distance to the nearest target, so close-range missiles fly nearly straight to their target while long-range missiles maintain their dramatic arcing behavior. This addresses GitHub Issue #69 item 2.

**Depends on**: PR #72 (`autopilot/remove-drone-ability`) — the missile is now ability slot 4 after drone removal.

## Changes

The change modifies two methods in `AbilitySystem.ts`:

**1. `spawnMissile()` — distance-scaled launch spread**

Previously, all missiles launched with a fixed ±108° random spread. Now the spread scales smoothly based on distance to the nearest visible enemy:
- **Close targets (<80px)**: ±30° spread — missile fires nearly at the enemy
- **Far targets (>250px)**: ±108° spread — full arcing behavior preserved
- **Between**: smooth linear interpolation

The method now iterates entities to find the nearest visible enemy distance (replacing the previous `entities.some()` check), which is a negligible cost since `spawnMissile` only runs on ability activation, not every frame.

**2. `updateMissiles()` — distance-scaled turn rate**

Previously, all missiles steered with a fixed `turnRate` of 3.5 rad/s. Now the effective turn rate scales inversely with distance using the formula: `effectiveTurnRate = baseTurnRate * max(1, 175 / clamp(dist, 30, 300))`:
- **30px**: ~20.4 rad/s (nearly instant aim correction)
- **175px**: 3.5 rad/s (standard behavior, unchanged)
- **300px+**: 3.5 rad/s (clamped to base rate minimum via `max(1, ...)`)

This uses the already-computed `nearestDistSq` from the existing tracking loop — no additional iteration or allocation.

## Decisions Made

| Question | Decision | Rationale |
|----------|----------|-----------|
| Where to compute distance for spread? | In `spawnMissile()` | Already iterating entities for target check |
| Turn rate formula | `baseTurnRate * max(1, 175/clamp(dist,30,300))` | Smooth inverse scaling, ~20 at close, ~3.5 at medium, never below base |
| Spread interpolation range | 80-250px | Matches game's close/medium range feel |

## PRDs Completed
1. **prd-001** [frontend] — Distance-based missile aim directness

## Test Coverage
- 5 new behavioral tests in `AbilitySystem.test.ts` under `distance-based aim directness`:
  - Higher effective turn rate for close vs far targets (statistical, multi-trial)
  - Narrower launch spread for close targets (50 samples)
  - Wider launch spread for far targets (50 samples)
  - Close-range missiles hit reliably (10/10 trials)
  - Smooth interpolation: close > medium > far turn rates
- All 407 existing tests pass
- TypeScript strict mode passes

## Quality Gates
- [x] Tests: 407/407 passing
- [x] TypeScript: strict mode, no errors
- [x] Code review: PASS
- [x] No allocations added to hot path

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2