### PR TITLE
Canvas layer separation — transparent 2D overlay over 3D scene

### DIFF
--- a/src/canvas.test.ts
+++ b/src/canvas.test.ts
@@ -27,6 +27,12 @@ describe('createCanvas', () => {
     expect(canvas.height).toBe(768);
   });
 
+  it('positions canvas with z-index for 3D layering', () => {
+    const canvas = createCanvas('game-canvas');
+    expect(canvas.style.position).toBe('absolute');
+    expect(canvas.style.zIndex).toBe('1');
+  });
+
   it('resizes canvas when the window resizes', () => {
     Object.defineProperty(window, 'innerWidth', { value: 800, writable: true });
     Object.defineProperty(window, 'innerHeight', { value: 600, writable: true });

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -4,6 +4,13 @@ export function createCanvas(elementId: string): HTMLCanvasElement {
     throw new Error(`Canvas element with id "${elementId}" not found`);
   }
 
+  // Position the 2D canvas for z-index layering:
+  // 3D canvas (z-index 0, behind) -> 2D canvas (z-index 1, middle) -> ShaderPipeline (z-index 2, top)
+  canvas.style.position = 'absolute';
+  canvas.style.top = '0';
+  canvas.style.left = '0';
+  canvas.style.zIndex = '1';
+
   function resize() {
     canvas!.width = window.innerWidth;
     canvas!.height = window.innerHeight;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { Player } from './entities/Player';
 import { InputSystem } from './systems/InputSystem';
 import { PingSystem } from './systems/PingSystem';
 import { CombatSystem } from './systems/CombatSystem';
-import { Enemy, GameEntity, Dropoff, HomeBase, createHomeBase } from './entities/Entity';
+import { Enemy, GameEntity, HomeBase, createHomeBase } from './entities/Entity';
 import { spawnWave, spawnBoss } from './systems/WaveSpawner';
 import { BossSystem } from './systems/BossSystem';
 import { HomebaseUpgradeSystem } from './systems/HomebaseUpgradeSystem';
@@ -28,7 +28,7 @@ import { MotionTrail } from './radar/MotionTrail';
 import { DeathParticles } from './radar/DeathParticles';
 import { TowRopeSystem } from './systems/TowRopeSystem';
 import { CombatBotSystem } from './systems/CombatBotSystem';
-import { MiningBotSystem, MiningBotState } from './systems/MiningBotSystem';
+import { MiningBotSystem } from './systems/MiningBotSystem';
 import { BotSlotSystem, SlotState } from './systems/BotSlotSystem';
 import { createZoomState, adjustZoom, updateZoom, resetZoom, ZOOM_WHEEL_SENSITIVITY, ZOOM_KEY_STEP, ZoomState } from './systems/ZoomState';
 import { Minimap } from './ui/Minimap';
@@ -1139,8 +1139,11 @@ const loop = new GameLoop({
     const cx = canvas.width / 2 + screenShake.offsetX;
     const cy = canvas.height / 2 + screenShake.offsetY;
 
-    // 3D renderer pass (renders behind the 2D canvas)
+    const theme = getTheme();
+
+    // 3D renderer pass — renders the background and (future) 3D entities
     if (renderer3d) {
+      renderer3d.setClearColor(theme.radar.background);
       renderer3d.beginFrame(player.x, player.y, player.heading, zoom.current);
       if (testCubeHandle) {
         renderer3d.drawMesh(testCubeHandle, 0, 0); // Test cube at world origin
@@ -1148,9 +1151,18 @@ const loop = new GameLoop({
       renderer3d.endFrame();
     }
 
-    const theme = getTheme();
-    ctx.fillStyle = theme.radar.background;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    // Clear the 2D canvas transparently so the 3D scene shows through,
+    // then blit the 3D canvas as the background layer for compositing.
+    // The ShaderPipeline reads only the 2D canvas, so we must composite
+    // the 3D content into it before the shader pass.
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    if (renderer3d) {
+      ctx.drawImage(renderer3d.getCanvas(), 0, 0);
+    } else {
+      // Fallback when WebGL2 is unavailable — draw opaque background
+      ctx.fillStyle = theme.radar.background;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
 
     // Radar (drawn without rotation — rings/crosshair are fixed, but scaled with zoom)
     radar.render(ctx, cx, cy, player.x, player.y, player.heading, zoom.current);
@@ -1167,362 +1179,32 @@ const loop = new GameLoop({
     // View radius covers the full screen — divide by zoom so we don't cull entities that are
     // visible when zoomed out (zoom < 1 means more world is visible)
     const viewRadius = Math.sqrt(canvas.width * canvas.width + canvas.height * canvas.height) / 2 / zoom.current;
-    const viewRadiusSq = viewRadius * viewRadius;
-
     ambientParticles.renderDeep(ctx, cx, cy, viewRadius, player.x, player.y);
 
-    // Motion trails (rendered behind blips)
-    motionTrail.render(ctx, player.x, player.y, cx, cy);
+    // ── 3D MIGRATION ──────────────────────────────────────────────────────
+    // The following entity rendering has been removed from the 2D canvas.
+    // These will be rendered by the 3D renderer in subsequent work items:
+    //   - Motion trails (MotionTrail)
+    //   - Home base (boundary ring, hexagon)
+    //   - Combat bots (chevrons, health bars)
+    //   - Combat bot projectiles
+    //   - Dropoff zones (pulsing rings)
+    //   - Tow ropes and towed salvage
+    //   - Entity blips (asteroids, enemies, salvage via BlipRenderer)
+    //   - Death particles
+    //   - Enemy projectiles
+    //   - Mining bots and laser lines
+    //   - Homing missiles
+    //   - Mouse cursor crosshair
+    // ────────────────────────────────────────────────────────────────────────
 
-    // Home base — boundary ring and center marker (tints toward red when damaged)
-    {
-      const hbx = homeBase.x - player.x;
-      const hby = homeBase.y - player.y;
-      if (hbx * hbx + hby * hby <= viewRadiusSq) {
-        const hsx = cx + hbx;
-        const hsy = cy + hby;
-        const pulse = 1 + Math.sin(player.survivalTime * 1.5) * 0.05;
-
-        // Interpolate color from cyan (100,220,255) to red (255,60,60) based on damage
-        const hpRatio = homeBase.maxHealth > 0 ? homeBase.health / homeBase.maxHealth : 1;
-        const hbR = Math.round(100 + (255 - 100) * (1 - hpRatio));
-        const hbG = Math.round(220 * hpRatio + 60 * (1 - hpRatio));
-        const hbB = Math.round(255 * hpRatio + 60 * (1 - hpRatio));
-        const hbHex = `#${hbR.toString(16).padStart(2, '0')}${hbG.toString(16).padStart(2, '0')}${hbB.toString(16).padStart(2, '0')}`;
-
-        ctx.save();
-
-        // Outer boundary ring
-        ctx.beginPath();
-        ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.25)`;
-        ctx.lineWidth = 2;
-        ctx.shadowColor = hbHex;
-        ctx.shadowBlur = 10;
-        ctx.stroke();
-
-        // Inner glow fill
-        ctx.beginPath();
-        ctx.arc(hsx, hsy, homeBase.radius * pulse, 0, Math.PI * 2);
-        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.03)`;
-        ctx.fill();
-
-        // Inner ring (second boundary line for depth)
-        ctx.beginPath();
-        ctx.arc(hsx, hsy, homeBase.radius * 0.6 * pulse, 0, Math.PI * 2);
-        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.12)`;
-        ctx.lineWidth = 1;
-        ctx.shadowBlur = 0;
-        ctx.stroke();
-
-        // Center structure — hexagon shape
-        ctx.translate(hsx, hsy);
-        const hexRadius = 10;
-        ctx.beginPath();
-        for (let i = 0; i < 6; i++) {
-          const angle = (Math.PI / 3) * i - Math.PI / 6;
-          const hxp = Math.cos(angle) * hexRadius;
-          const hyp = Math.sin(angle) * hexRadius;
-          if (i === 0) ctx.moveTo(hxp, hyp);
-          else ctx.lineTo(hxp, hyp);
-        }
-        ctx.closePath();
-        ctx.fillStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.4)`;
-        ctx.strokeStyle = `rgba(${hbR}, ${hbG}, ${hbB}, 0.7)`;
-        ctx.lineWidth = 1.5;
-        ctx.shadowColor = hbHex;
-        ctx.shadowBlur = 8;
-        ctx.fill();
-        ctx.stroke();
-
-        ctx.restore();
-      }
-    }
-
-    // Combat bots — blue chevrons with health indicator
-    {
-      const combatColor = theme.entities.combatBot;
-      for (let i = 0; i < combatBotSystem.bots.length; i++) {
-        const bot = combatBotSystem.bots[i];
-        if (!bot.active) continue;
-        const bdx = bot.x - player.x;
-        const bdy = bot.y - player.y;
-        if (bdx * bdx + bdy * bdy > viewRadiusSq) continue;
-        const bsx = cx + bdx;
-        const bsy = cy + bdy;
-
-        // Pulsing glow based on remaining lifetime
-        const lifeFrac = bot.lifetime / bot.maxLifetime;
-        const pulseAlpha = lifeFrac > 0.25 ? 0.8 : 0.4 + Math.sin(player.survivalTime * 8) * 0.4;
-        ctx.globalAlpha = pulseAlpha;
-
-        // Chevron/arrow shape — signals active, aggressive friendly
-        ctx.beginPath();
-        ctx.moveTo(bsx, bsy - 5);
-        ctx.lineTo(bsx + 4, bsy + 3);
-        ctx.lineTo(bsx + 1, bsy + 1);
-        ctx.lineTo(bsx, bsy + 4);
-        ctx.lineTo(bsx - 1, bsy + 1);
-        ctx.lineTo(bsx - 4, bsy + 3);
-        ctx.closePath();
-        ctx.fillStyle = combatColor;
-        ctx.fill();
-
-        // Health bar above bot (only if damaged)
-        if (bot.health < bot.maxHealth) {
-          const hpFrac = bot.health / bot.maxHealth;
-          ctx.globalAlpha = 0.7;
-          ctx.fillStyle = '#333';
-          ctx.fillRect(bsx - 6, bsy - 10, 12, 2);
-          ctx.fillStyle = hpFrac > 0.5 ? combatColor : '#ff4444';
-          ctx.fillRect(bsx - 6, bsy - 10, 12 * hpFrac, 2);
-        }
-        ctx.globalAlpha = 1;
-      }
-    }
-
-    // Combat bot projectiles — small cyan dots
-    {
-      const projColor = theme.entities.botProjectile;
-      for (let i = 0; i < combatBotSystem.botProjectiles.length; i++) {
-        const p = combatBotSystem.botProjectiles[i];
-        if (!p.active) continue;
-        const pdx = p.x - player.x;
-        const pdy = p.y - player.y;
-        if (pdx * pdx + pdy * pdy > viewRadiusSq) continue;
-        const psx = cx + pdx;
-        const psy = cy + pdy;
-        ctx.beginPath();
-        ctx.arc(psx, psy, 2.5, 0, Math.PI * 2);
-        ctx.fillStyle = projColor;
-        ctx.fill();
-      }
-    }
-
-    // Dropoff zones — pulsing ring markers
-    for (const entity of world.entities) {
-      if (!entity.active || entity.type !== 'dropoff') continue;
-      const dropoff = entity as Dropoff;
-      const ddx = dropoff.x - player.x;
-      const ddy = dropoff.y - player.y;
-      if (ddx * ddx + ddy * ddy > viewRadiusSq) continue;
-      const dsx = cx + (dropoff.x - player.x);
-      const dsy = cy + (dropoff.y - player.y);
-      const pulse = 1 + Math.sin(player.survivalTime * 2) * 0.08;
-
-      const dropoffColor = theme.entities.dropoff;
-      ctx.save();
-      // Outer ring
-      ctx.beginPath();
-      ctx.arc(dsx, dsy, dropoff.radius * pulse, 0, Math.PI * 2);
-      ctx.strokeStyle = dropoffColor;
-      ctx.globalAlpha = 0.3;
-      ctx.lineWidth = 2;
-      ctx.shadowColor = dropoffColor;
-      ctx.shadowBlur = 8;
-      ctx.stroke();
-
-      // Inner glow fill
-      ctx.globalAlpha = 0.04;
-      ctx.beginPath();
-      ctx.arc(dsx, dsy, dropoff.radius * pulse, 0, Math.PI * 2);
-      ctx.fillStyle = dropoffColor;
-      ctx.fill();
-
-      // Center diamond marker
-      ctx.globalAlpha = 0.6;
-      ctx.translate(dsx, dsy);
-      ctx.rotate(Math.PI / 4);
-      ctx.beginPath();
-      ctx.rect(-5, -5, 10, 10);
-      ctx.strokeStyle = dropoffColor;
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
-      ctx.restore();
-    }
-
-    // Tow ropes and towed salvage blips (hub-and-spoke: all anchored to player)
-    const towedItems = towRopeSystem.getTowedItems();
-    if (towedItems.length > 0) {
-      ctx.save();
-      for (const item of towedItems) {
-        const sal = item.salvage;
-        const itemSX = cx + (sal.x - player.x);
-        const itemSY = cy + (sal.y - player.y);
-
-        // Fade-out alpha
-        const alpha = item.fadeOut !== null ? Math.max(0, item.fadeOut / 0.3) : 1;
-        ctx.globalAlpha = alpha;
-
-        // Bezier rope: control point offset perpendicular to line by velocity delta
-        const midX = (cx + itemSX) / 2;
-        const midY = (cy + itemSY) / 2;
-        const dvx = player.vx - item.vx;
-        const dvy = player.vy - item.vy;
-        const cpX = midX + (-dvy) * 0.3;
-        const cpY = midY + dvx * 0.3;
-
-        // Draw rope
-        const salvageColor = theme.entities.salvage;
-        ctx.beginPath();
-        ctx.moveTo(cx, cy);
-        ctx.quadraticCurveTo(cpX, cpY, itemSX, itemSY);
-        ctx.strokeStyle = salvageColor;
-        ctx.globalAlpha = 0.5 * alpha;
-        ctx.lineWidth = 1.5;
-        ctx.shadowColor = salvageColor;
-        ctx.shadowBlur = 4;
-        ctx.stroke();
-
-        // Draw towed salvage blip (diamond shape)
-        ctx.save();
-        ctx.globalAlpha = alpha;
-        ctx.translate(itemSX, itemSY);
-        ctx.rotate(Math.PI / 4);
-        ctx.beginPath();
-        ctx.rect(-4.5, -4.5, 9, 9);
-        ctx.fillStyle = salvageColor;
-        ctx.shadowColor = salvageColor;
-        ctx.shadowBlur = 8;
-        ctx.fill();
-
-        // Damage flash overlay — white flash when recently hit
-        if (item.salvage.damageFlash > 0) {
-          ctx.globalAlpha = Math.min(item.salvage.damageFlash / 0.15, 1);
-          ctx.fillStyle = '#ffffff';
-          ctx.shadowBlur = 0;
-          ctx.fill();
-        }
-
-        ctx.restore();
-      }
-      ctx.globalAlpha = 1;
-      ctx.shadowBlur = 0;
-      ctx.restore();
-    }
-
-    // Entity blips (positions are rotated by the canvas transform)
-    const worldRot = -player.heading - Math.PI / 2;
-    blipRenderer.renderBlips(
-      ctx,
-      world.entities,
-      player.x,
-      player.y,
-      cx,
-      cy,
-      viewRadius,
-      resolutionLevel,
-      worldRot
-    );
+    // Sweep effects (radar ping visual feedback — stays on 2D overlay)
     sweepEffects.render(ctx, cx, cy);
 
-    // Ability visual effects
+    // Ability visual effects (player feedback — stays on 2D overlay)
     abilityEffects.render(ctx, cx, cy, player.x, player.y, player.survivalTime);
 
-    // Death particles
-    deathParticles.render(ctx, player.x, player.y, cx, cy, viewRadius);
-
-    // Render projectiles
-    for (const p of combatSystem.projectiles) {
-      const prx = p.x - player.x;
-      const pry = p.y - player.y;
-      if (prx * prx + pry * pry > viewRadiusSq) continue;
-      const px = cx + prx;
-      const py = cy + pry;
-      ctx.save();
-      ctx.shadowColor = theme.effects.projectileGlow;
-      ctx.shadowBlur = 6;
-      ctx.beginPath();
-      ctx.arc(px, py, 2, 0, Math.PI * 2);
-      ctx.fillStyle = theme.effects.projectile;
-      ctx.fill();
-      ctx.restore();
-    }
-
-    // Render mining bots and laser lines
-    {
-      const miningColor = theme.entities.miningBot;
-      const bots = miningBotSystem.getBots();
-      for (let i = 0; i < bots.length; i++) {
-        const mb = bots[i];
-        if (!mb.active) continue;
-        const mbrx = mb.x - player.x;
-        const mbry = mb.y - player.y;
-        if (mbrx * mbrx + mbry * mbry > viewRadiusSq) continue;
-        const mbX = cx + mbrx;
-        const mbY = cy + mbry;
-
-        // Laser line to asteroid while mining
-        if (mb.state === MiningBotState.Mining && mb.targetAsteroid) {
-          const tarx = mb.targetAsteroid.x - player.x;
-          const tary = mb.targetAsteroid.y - player.y;
-          const tarX = cx + tarx;
-          const tarY = cy + tary;
-          ctx.save();
-          ctx.strokeStyle = miningColor;
-          ctx.globalAlpha = 0.6;
-          ctx.lineWidth = 1;
-          ctx.beginPath();
-          ctx.moveTo(mbX, mbY);
-          ctx.lineTo(tarX, tarY);
-          ctx.stroke();
-          ctx.restore();
-        }
-
-        // Bot dot — double circle (filled inner + outer ring)
-        ctx.save();
-        ctx.shadowColor = miningColor;
-        ctx.shadowBlur = 8;
-        ctx.beginPath();
-        ctx.arc(mbX, mbY, 3, 0, Math.PI * 2);
-        ctx.fillStyle = miningColor;
-        ctx.fill();
-        // Outer ring
-        ctx.beginPath();
-        ctx.arc(mbX, mbY, 5, 0, Math.PI * 2);
-        ctx.strokeStyle = miningColor;
-        ctx.lineWidth = 1;
-        ctx.stroke();
-        ctx.restore();
-      }
-    }
-
-    // Render missiles
-    for (const missile of abilitySystem.missiles) {
-      const mrx = missile.x - player.x;
-      const mry = missile.y - player.y;
-      if (mrx * mrx + mry * mry > viewRadiusSq) continue;
-      const mx = cx + mrx;
-      const my = cy + mry;
-      ctx.save();
-      ctx.shadowColor = theme.effects.missile;
-      ctx.shadowBlur = 10;
-      ctx.beginPath();
-      ctx.arc(mx, my, 3, 0, Math.PI * 2);
-      ctx.fillStyle = theme.effects.missile;
-      ctx.fill();
-      ctx.restore();
-    }
-
-    // Mouse cursor indicator (crosshair at mouse world position)
-    if (input.mouseOver) {
-      const cursorSX = cx + (input.mouseWorldX - player.x);
-      const cursorSY = cy + (input.mouseWorldY - player.y);
-      ctx.globalAlpha = 0.3;
-      ctx.strokeStyle = theme.radar.primary;
-      ctx.lineWidth = 1;
-      ctx.beginPath();
-      // Horizontal line
-      ctx.moveTo(cursorSX - 8, cursorSY);
-      ctx.lineTo(cursorSX + 8, cursorSY);
-      // Vertical line
-      ctx.moveTo(cursorSX, cursorSY - 8);
-      ctx.lineTo(cursorSX, cursorSY + 8);
-      ctx.stroke();
-      ctx.globalAlpha = 1.0;
-    }
-
-    // Floating text (counter-rotated so text stays upright)
+    // Floating text (counter-rotated so text stays upright — stays on 2D overlay)
     const worldRotation = -player.heading - Math.PI / 2;
     floatingText.render(ctx, player.x, player.y, cx, cy, worldRotation);
 
@@ -1540,19 +1222,7 @@ const loop = new GameLoop({
     ctx.fill();
     ctx.restore();
 
-    // Player heading indicator (fixed to screen, always points up)
-    ctx.save();
-    ctx.translate(cx, cy);
-    ctx.fillStyle = theme.radar.primary;
-    ctx.shadowColor = theme.radar.primary;
-    ctx.shadowBlur = 6;
-    ctx.beginPath();
-    ctx.moveTo(0, -8);
-    ctx.lineTo(-5, 5);
-    ctx.lineTo(5, 5);
-    ctx.closePath();
-    ctx.fill();
-    ctx.restore();
+    // [3D-MIGRATION] Player heading indicator — removed from 2D, will be rendered in 3D
 
     // Bot slot UI — row of small circles below the player indicator
     {

--- a/src/rendering/Renderer3D.test.ts
+++ b/src/rendering/Renderer3D.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Renderer3D } from './Renderer3D';
+
+function createMockGL() {
+  const gl = {
+    VERTEX_SHADER: 35633,
+    FRAGMENT_SHADER: 35632,
+    COMPILE_STATUS: 35713,
+    LINK_STATUS: 35714,
+    DEPTH_TEST: 2929,
+    LEQUAL: 515,
+    CULL_FACE: 2884,
+    BACK: 1029,
+    COLOR_BUFFER_BIT: 16384,
+    DEPTH_BUFFER_BIT: 256,
+    TRIANGLES: 4,
+    UNSIGNED_SHORT: 5123,
+    FLOAT: 5126,
+    ARRAY_BUFFER: 34962,
+    ELEMENT_ARRAY_BUFFER: 34963,
+    STATIC_DRAW: 35044,
+    createShader: vi.fn(() => ({ __shader: true })),
+    shaderSource: vi.fn(),
+    compileShader: vi.fn(),
+    getShaderParameter: vi.fn(() => true),
+    getShaderInfoLog: vi.fn(() => ''),
+    createProgram: vi.fn(() => ({ __program: true })),
+    attachShader: vi.fn(),
+    linkProgram: vi.fn(),
+    getProgramParameter: vi.fn(() => true),
+    getProgramInfoLog: vi.fn(() => ''),
+    useProgram: vi.fn(),
+    getUniformLocation: vi.fn(() => ({ __loc: true })),
+    uniform3fv: vi.fn(),
+    uniformMatrix4fv: vi.fn(),
+    enable: vi.fn(),
+    depthFunc: vi.fn(),
+    cullFace: vi.fn(),
+    clearColor: vi.fn(),
+    clear: vi.fn(),
+    viewport: vi.fn(),
+    createVertexArray: vi.fn(() => ({ __vao: true })),
+    bindVertexArray: vi.fn(),
+    deleteVertexArray: vi.fn(),
+    createBuffer: vi.fn(() => ({ __buffer: true })),
+    bindBuffer: vi.fn(),
+    bufferData: vi.fn(),
+    enableVertexAttribArray: vi.fn(),
+    vertexAttribPointer: vi.fn(),
+    deleteBuffer: vi.fn(),
+    drawElements: vi.fn(),
+    deleteProgram: vi.fn(),
+  } as unknown as WebGL2RenderingContext;
+  return gl;
+}
+
+function withMockRenderer(fn: (renderer: Renderer3D, gl: ReturnType<typeof createMockGL>) => void) {
+  const mockGL = createMockGL();
+  const origGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = vi.fn(function (this: HTMLCanvasElement, type: string) {
+    if (type === 'webgl2') return mockGL;
+    return origGetContext.call(this, type);
+  }) as typeof origGetContext;
+
+  try {
+    const sourceCanvas = document.createElement('canvas');
+    sourceCanvas.width = 800;
+    sourceCanvas.height = 600;
+    document.body.appendChild(sourceCanvas);
+    const renderer = Renderer3D.create(sourceCanvas)!;
+    expect(renderer).not.toBeNull();
+    fn(renderer, mockGL);
+    renderer.dispose();
+  } finally {
+    HTMLCanvasElement.prototype.getContext = origGetContext;
+  }
+}
+
+describe('Renderer3D', () => {
+  describe('create', () => {
+    it('returns null when WebGL2 is not available', () => {
+      const sourceCanvas = document.createElement('canvas');
+      sourceCanvas.width = 800;
+      sourceCanvas.height = 600;
+      document.body.appendChild(sourceCanvas);
+      const renderer = Renderer3D.create(sourceCanvas);
+      expect(renderer).toBeNull();
+    });
+
+    it('creates a 3D canvas behind the source canvas', () => {
+      withMockRenderer((renderer) => {
+        const canvas3d = renderer.getCanvas();
+        expect(canvas3d).toBeInstanceOf(HTMLCanvasElement);
+        expect(canvas3d.style.zIndex).toBe('0');
+        expect(canvas3d.style.pointerEvents).toBe('none');
+      });
+    });
+  });
+
+  describe('setClearColor', () => {
+    it('sets the clear color from a 6-digit hex string', () => {
+      withMockRenderer((renderer, gl) => {
+        renderer.setClearColor('#1a2b3c');
+        // Need to call beginFrame to see the clearColor call
+        renderer.beginFrame(0, 0, 0, 1);
+        expect(gl.clearColor).toHaveBeenCalledWith(
+          expect.closeTo(0x1a / 255, 2),
+          expect.closeTo(0x2b / 255, 2),
+          expect.closeTo(0x3c / 255, 2),
+          1
+        );
+      });
+    });
+
+    it('sets the clear color from a 3-digit hex string', () => {
+      withMockRenderer((renderer, gl) => {
+        renderer.setClearColor('#abc');
+        renderer.beginFrame(0, 0, 0, 1);
+        expect(gl.clearColor).toHaveBeenCalledWith(
+          expect.closeTo(0xaa / 255, 2),
+          expect.closeTo(0xbb / 255, 2),
+          expect.closeTo(0xcc / 255, 2),
+          1
+        );
+      });
+    });
+  });
+
+  describe('getCanvas', () => {
+    it('returns the underlying 3D canvas element', () => {
+      withMockRenderer((renderer) => {
+        const canvas3d = renderer.getCanvas();
+        expect(canvas3d).toBeInstanceOf(HTMLCanvasElement);
+        expect(canvas3d.style.position).toBe('absolute');
+      });
+    });
+  });
+});

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -65,6 +65,24 @@ export interface MeshHandle {
   indexBuffer: WebGLBuffer;
 }
 
+// ─── Hex color parsing ──────────────────────────────────────────────────
+
+/** Parse a hex color string (#rgb, #rrggbb) into [r, g, b] floats 0-1 */
+function parseHexColor(hex: string): [number, number, number] {
+  const h = hex.replace('#', '');
+  let r: number, g: number, b: number;
+  if (h.length === 3) {
+    r = parseInt(h[0] + h[0], 16) / 255;
+    g = parseInt(h[1] + h[1], 16) / 255;
+    b = parseInt(h[2] + h[2], 16) / 255;
+  } else {
+    r = parseInt(h.substring(0, 2), 16) / 255;
+    g = parseInt(h.substring(2, 4), 16) / 255;
+    b = parseInt(h.substring(4, 6), 16) / 255;
+  }
+  return [r, g, b];
+}
+
 // ─── Camera height and tilt ──────────────────────────────────────────────
 
 /** Camera height above the ground plane */
@@ -92,6 +110,12 @@ export class Renderer3D {
   private uModel: WebGLUniformLocation | null;
   private uLightDir: WebGLUniformLocation | null;
   private uAmbient: WebGLUniformLocation | null;
+
+  // Clear color (defaults to transparent black)
+  private clearR = 0;
+  private clearG = 0;
+  private clearB = 0;
+  private clearA = 1;
 
   // Current camera matrices (reused each frame)
   private projectionMatrix: Float32Array = mat4.identity();
@@ -136,6 +160,7 @@ export class Renderer3D {
     canvas3d.style.width = '100%';
     canvas3d.style.height = '100%';
     canvas3d.style.pointerEvents = 'none';
+    canvas3d.style.zIndex = '0';
 
     const gl = canvas3d.getContext('webgl2');
     if (!gl) return null;
@@ -238,8 +263,8 @@ export class Renderer3D {
       gl.viewport(0, 0, w, h);
     }
 
-    // Clear
-    gl.clearColor(0, 0, 0, 0);
+    // Clear with the configured background color
+    gl.clearColor(this.clearR, this.clearG, this.clearB, this.clearA);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     gl.useProgram(this.program);
@@ -315,6 +340,24 @@ export class Renderer3D {
     this.canvas3d.width = w;
     this.canvas3d.height = h;
     this.gl.viewport(0, 0, w, h);
+  }
+
+  /**
+   * Set the clear color from a CSS hex color string (e.g. '#0a0a0a').
+   * Called each frame or when the theme changes so the 3D background
+   * matches the game's theme.
+   */
+  setClearColor(hex: string): void {
+    const [r, g, b] = parseHexColor(hex);
+    this.clearR = r;
+    this.clearG = g;
+    this.clearB = b;
+    this.clearA = 1;
+  }
+
+  /** Get the underlying 3D canvas element (for compositing into the 2D canvas) */
+  getCanvas(): HTMLCanvasElement {
+    return this.canvas3d;
   }
 
   /** Clean up all GPU resources */

--- a/src/rendering/ShaderPipeline.ts
+++ b/src/rendering/ShaderPipeline.ts
@@ -81,6 +81,8 @@ export class ShaderPipeline {
     glCanvas.style.left = '0';
     glCanvas.style.width = '100%';
     glCanvas.style.height = '100%';
+    // Sit on top of both the 3D canvas (z-index 0) and the 2D canvas (z-index 1)
+    glCanvas.style.zIndex = '2';
     // Let clicks pass through to the source canvas underneath (preserves event handlers)
     glCanvas.style.pointerEvents = 'none';
 


### PR DESCRIPTION
## Summary

Restructures the canvas layering so the 2D canvas becomes a transparent overlay on top of the 3D WebGL canvas. The 3D renderer now draws the background color (from the active theme), and its output is composited into the 2D canvas via `drawImage` before the ShaderPipeline post-processing reads it. Entity rendering has been removed from the 2D canvas — these entities will be rendered in 3D in subsequent work items.

## Changes

The render pipeline now works in this order during gameplay:

1. **Renderer3D** clears with the theme background color via `setClearColor()` and draws 3D content (currently just the test cube)
2. **2D canvas** is cleared transparently (`clearRect`), then the 3D canvas is blitted onto it as a background layer
3. **Radar rings, sweep effects, ability effects, floating text, ambient particles** render on the 2D overlay
4. **HUD, minimap, ability bar, bot slots, boss indicator, damage flash, menus** render on the 2D overlay (unrotated)
5. **ShaderPipeline** reads the composited 2D canvas and applies bloom + damage distortion

Entity rendering removed from 2D (intentionally missing — to be replaced by 3D meshes in wi-004+):
- Entity blips (asteroids, enemies, salvage), home base, combat bots, mining bots, projectiles, tow ropes, motion trails, death particles, player heading indicator, dropoff zones, missiles, mouse cursor crosshair

Z-index layering: 3D canvas (0) → 2D canvas (1) → ShaderPipeline WebGL canvas (2)

base_mode and menu screens remain fully 2D with opaque backgrounds — no 3D compositing in those states.

When WebGL2 is unavailable, the game falls back to the original opaque 2D background.

## PRDs Completed

1. **prd-001** [frontend]: Canvas layer separation with transparent 2D overlay

## Test Coverage

- 589 tests passing (6 new)
- New: Renderer3D tests for `setClearColor` (hex parsing), `getCanvas`, `create` factory
- New: Canvas z-index positioning test
- All existing tests unaffected

## Quality Gates

- [x] Tests: 589/589 passing
- [x] TypeScript: clean (`tsc --noEmit`)
- [x] Build: `npm run build` succeeds
- [x] No unused imports or dead code

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2