### PR TITLE
3D entity rendering: asteroids and home base

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,8 @@ import { BotSlotSystem, SlotState } from './systems/BotSlotSystem';
 import { createZoomState, adjustZoom, updateZoom, resetZoom, ZOOM_WHEEL_SENSITIVITY, ZOOM_KEY_STEP, ZoomState } from './systems/ZoomState';
 import { Minimap } from './ui/Minimap';
 import { ShaderPipeline } from './rendering/ShaderPipeline';
-import { Renderer3D, createTestCube, MeshHandle } from './rendering/Renderer3D';
+import { Renderer3D } from './rendering/Renderer3D';
+import { EntityRenderer3D } from './rendering/EntityRenderer3D';
 import { BloomEffect } from './rendering/effects/BloomEffect';
 import { DamageDistortionEffect } from './rendering/effects/DamageDistortionEffect';
 import { getTheme, cycleTheme } from './themes/theme';
@@ -60,9 +61,9 @@ if (shaderPipeline) {
 }
 // 3D renderer (renders behind the 2D canvas — optional, null if WebGL2 unavailable)
 const renderer3d = Renderer3D.create(canvas);
-let testCubeHandle: MeshHandle | null = null;
+let entityRenderer3d: EntityRenderer3D | null = null;
 if (renderer3d) {
-  testCubeHandle = renderer3d.uploadMesh(createTestCube(15));
+  entityRenderer3d = new EntityRenderer3D(renderer3d);
 }
 const pauseMenu = new PauseMenu();
 const helpScreen = new HelpScreen();
@@ -1141,13 +1142,26 @@ const loop = new GameLoop({
 
     const theme = getTheme();
 
-    // 3D renderer pass — renders the background and (future) 3D entities
-    if (renderer3d) {
+    // 3D renderer pass — renders background, asteroids, and home base
+    if (renderer3d && entityRenderer3d) {
       renderer3d.setClearColor(theme.radar.background);
       renderer3d.beginFrame(player.x, player.y, player.heading, zoom.current);
-      if (testCubeHandle) {
-        renderer3d.drawMesh(testCubeHandle, 0, 0); // Test cube at world origin
-      }
+
+      // View radius for culling — same formula used for 2D rendering below
+      const viewRadius3d = Math.sqrt(canvas.width * canvas.width + canvas.height * canvas.height) / 2 / zoom.current;
+
+      // Render asteroids with rotation, damage flash, mining darkening, and culling
+      entityRenderer3d.renderAsteroids(
+        world.entities,
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
+      // Render home base with HP-based red tinting and pulse
+      entityRenderer3d.renderHomeBase(homeBase, player.survivalTime);
+
       renderer3d.endFrame();
     }
 

--- a/src/rendering/EntityRenderer3D.test.ts
+++ b/src/rendering/EntityRenderer3D.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EntityRenderer3D } from './EntityRenderer3D';
+import type { Renderer3D, MeshHandle } from './Renderer3D';
+import type { Asteroid, HomeBase, GameEntity } from '../entities/Entity';
+import { createAsteroid, createHomeBase } from '../entities/Entity';
+
+// ─── Mock Renderer ──────────────────────────────────────────────────────
+
+function createMockRenderer() {
+  let handleId = 0;
+  const drawMeshTintedCalls: {
+    handle: MeshHandle;
+    worldX: number;
+    worldY: number;
+    rotationY: number;
+    scale: number;
+    tintR: number;
+    tintG: number;
+    tintB: number;
+    flash: number;
+  }[] = [];
+
+  const renderer = {
+    uploadMesh: vi.fn(() => {
+      handleId++;
+      return {
+        vao: { __vao: handleId },
+        indexCount: 60,
+        positionBuffer: { __buf: 'pos' + handleId },
+        normalBuffer: { __buf: 'norm' + handleId },
+        colorBuffer: { __buf: 'col' + handleId },
+        indexBuffer: { __buf: 'idx' + handleId },
+      } as unknown as MeshHandle;
+    }),
+    drawMeshTinted: vi.fn(
+      (handle: MeshHandle, worldX: number, worldY: number, rotationY: number, scale: number, tintR: number, tintG: number, tintB: number, flash: number) => {
+        drawMeshTintedCalls.push({ handle, worldX, worldY, rotationY, scale, tintR, tintG, tintB, flash });
+      },
+    ),
+    deleteMesh: vi.fn(),
+  } as unknown as Renderer3D;
+
+  return { renderer, drawMeshTintedCalls };
+}
+
+// ─── Test helpers ───────────────────────────────────────────────────────
+
+function makeAsteroid(overrides: Partial<Asteroid> = {}): Asteroid {
+  const base = createAsteroid(100, 200, 'medium');
+  return { ...base, ...overrides };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+describe('EntityRenderer3D', () => {
+  describe('constructor', () => {
+    it('uploads 30 asteroid meshes (10 per size) and 1 home base mesh', () => {
+      const { renderer } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // 10 small + 10 medium + 10 large + 1 home base = 31 uploads
+      expect(renderer.uploadMesh).toHaveBeenCalledTimes(31);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderAsteroids', () => {
+    it('renders active asteroids within view radius', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20, active: true }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(1);
+      expect(drawMeshTintedCalls[0].worldX).toBe(10);
+      expect(drawMeshTintedCalls[0].worldY).toBe(20);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls asteroids outside view radius', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 1000, y: 1000, active: true }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 100, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive asteroids', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20, active: false }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies damage flash when damageFlash > 0', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20, damageFlash: 0.7 }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls[0].flash).toBeCloseTo(0.7, 1);
+
+      entityRenderer.dispose();
+    });
+
+    it('darkens tint as mining progress increases', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20, miningProgress: 0.8 }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      // miningDarken = 1 - 0.8 * 0.5 = 0.6
+      expect(drawMeshTintedCalls[0].tintR).toBeCloseTo(0.6, 2);
+      expect(drawMeshTintedCalls[0].tintG).toBeCloseTo(0.6, 2);
+      expect(drawMeshTintedCalls[0].tintB).toBeCloseTo(0.6, 2);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders three different size categories', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 10, size: 'small' }),
+        makeAsteroid({ x: 20, y: 20, size: 'medium' }),
+        makeAsteroid({ x: 30, y: 30, size: 'large' }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(3);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies rotation based on time', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20 }),
+      ];
+
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 0);
+      const rotation0 = drawMeshTintedCalls[0].rotationY;
+
+      drawMeshTintedCalls.length = 0;
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 5);
+      const rotation5 = drawMeshTintedCalls[0].rotationY;
+
+      // Rotation should increase with time
+      expect(rotation5).toBeGreaterThan(rotation0);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderHomeBase', () => {
+    it('renders home base at its position', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const homeBase = createHomeBase(0, 0);
+      entityRenderer.renderHomeBase(homeBase, 0);
+
+      expect(drawMeshTintedCalls.length).toBe(1);
+      expect(drawMeshTintedCalls[0].worldX).toBe(0);
+      expect(drawMeshTintedCalls[0].worldY).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('tints red when home base is damaged', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const homeBase = createHomeBase(0, 0);
+      homeBase.health = 200; // 50% HP
+
+      entityRenderer.renderHomeBase(homeBase, 0);
+
+      // At 50% HP: tintG = 0.3 + 0.5*0.7 = 0.65, tintB = 0.65
+      expect(drawMeshTintedCalls[0].tintR).toBe(1);
+      expect(drawMeshTintedCalls[0].tintG).toBeCloseTo(0.65, 2);
+      expect(drawMeshTintedCalls[0].tintB).toBeCloseTo(0.65, 2);
+
+      entityRenderer.dispose();
+    });
+
+    it('has no red tint at full HP', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const homeBase = createHomeBase(0, 0);
+      // Full HP: tintG = 0.3 + 1.0*0.7 = 1.0, tintB = 1.0
+
+      entityRenderer.renderHomeBase(homeBase, 0);
+
+      expect(drawMeshTintedCalls[0].tintR).toBe(1);
+      expect(drawMeshTintedCalls[0].tintG).toBeCloseTo(1.0, 2);
+      expect(drawMeshTintedCalls[0].tintB).toBeCloseTo(1.0, 2);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies subtle scale pulse based on time', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const homeBase = createHomeBase(0, 0);
+
+      entityRenderer.renderHomeBase(homeBase, 0);
+      const scale0 = drawMeshTintedCalls[0].scale;
+
+      drawMeshTintedCalls.length = 0;
+      entityRenderer.renderHomeBase(homeBase, Math.PI / 4); // sin(PI/2) = 1
+      const scalePeak = drawMeshTintedCalls[0].scale;
+
+      // Pulse should vary the scale slightly
+      expect(scale0).toBeCloseTo(1.0, 1);
+      expect(scalePeak).toBeCloseTo(1.02, 2);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('dispose', () => {
+    it('deletes all uploaded meshes', () => {
+      const { renderer } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.dispose();
+
+      // 30 asteroid + 1 home base = 31 deletions
+      expect(renderer.deleteMesh).toHaveBeenCalledTimes(31);
+    });
+  });
+});

--- a/src/rendering/EntityRenderer3D.ts
+++ b/src/rendering/EntityRenderer3D.ts
@@ -1,0 +1,172 @@
+/**
+ * Entity render manager for 3D mesh rendering of asteroids and home base.
+ *
+ * Pre-generates a pool of asteroid mesh variants at init time (never in hot path).
+ * Each frame, iterates over active entities, culls by distance, and draws with
+ * appropriate tint, rotation, and damage flash.
+ */
+
+import type { Renderer3D, MeshHandle } from './Renderer3D';
+import type { Asteroid, GameEntity, HomeBase } from '../entities/Entity';
+import { createAsteroidMesh, createHomeBaseMesh } from './meshes';
+
+// ─── Constants ──────────────────────────────────────────────────────────
+
+/** Number of mesh variants per asteroid size */
+const VARIANTS_PER_SIZE = 10;
+
+/** Base rotation speed range (rad/s) */
+const ROTATION_SPEED_MIN = 0.2;
+const ROTATION_SPEED_RANGE = 0.3;
+
+/** Mining darkening: at full progress, color multiplied by this */
+const MINING_DARKEN_FACTOR = 0.5;
+
+/** Damage flash decay speed is handled by the game — we just read the value */
+
+// ─── Position hash for deterministic seeding ────────────────────────────
+
+/** Hash a position into a deterministic integer seed */
+function positionSeed(x: number, y: number): number {
+  // Large primes for spatial hashing, bitwise-or to integer
+  return ((x * 73856093) ^ (y * 19349663)) | 0;
+}
+
+// ─── EntityRenderer3D class ─────────────────────────────────────────────
+
+export class EntityRenderer3D {
+  private renderer: Renderer3D;
+
+  // Asteroid mesh pools: [small][0..9], [medium][0..9], [large][0..9]
+  private asteroidHandles: {
+    small: MeshHandle[];
+    medium: MeshHandle[];
+    large: MeshHandle[];
+  };
+
+  // Home base mesh
+  private homeBaseHandle: MeshHandle;
+
+  constructor(renderer: Renderer3D) {
+    this.renderer = renderer;
+
+    // Pre-generate asteroid mesh pool
+    this.asteroidHandles = {
+      small: [],
+      medium: [],
+      large: [],
+    };
+
+    const sizes = ['small', 'medium', 'large'] as const;
+    for (const size of sizes) {
+      for (let i = 0; i < VARIANTS_PER_SIZE; i++) {
+        const mesh = createAsteroidMesh(size, i * 7919 + 42);
+        this.asteroidHandles[size].push(renderer.uploadMesh(mesh));
+      }
+    }
+
+    // Pre-generate home base mesh
+    const homeBaseMesh = createHomeBaseMesh();
+    this.homeBaseHandle = renderer.uploadMesh(homeBaseMesh);
+  }
+
+  /**
+   * Render all visible asteroids from the entity list.
+   * Applies rotation, damage flash, mining darkening, and visibility culling.
+   */
+  renderAsteroids(
+    entities: readonly GameEntity[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      if (entity.type !== 'asteroid' || !entity.active) continue;
+
+      const asteroid = entity as Asteroid;
+
+      // Visibility culling: squared distance check
+      const dx = asteroid.x - playerX;
+      const dy = asteroid.y - playerY;
+      const distSq = dx * dx + dy * dy;
+      if (distSq > viewRadiusSq) continue;
+
+      // Determine mesh variant from position hash
+      const seed = positionSeed(asteroid.x, asteroid.y);
+      const variantIndex = ((seed & 0x7fffffff) % VARIANTS_PER_SIZE);
+      const handle = this.asteroidHandles[asteroid.size][variantIndex];
+
+      // Rotation: Y-axis, speed based on position seed
+      const seedFrac = ((seed & 0xffff) / 0xffff); // 0-1
+      const rotationSpeed = ROTATION_SPEED_MIN + seedFrac * ROTATION_SPEED_RANGE;
+      const rotationY = time * rotationSpeed;
+
+      // Tint: start white (no tint), darken with mining progress
+      const miningDarken = 1 - asteroid.miningProgress * MINING_DARKEN_FACTOR;
+      let tintR = miningDarken;
+      let tintG = miningDarken;
+      let tintB = miningDarken;
+
+      // Damage flash: override tint toward white
+      const flash = asteroid.damageFlash > 0 ? Math.min(asteroid.damageFlash, 1) : 0;
+
+      this.renderer.drawMeshTinted(
+        handle,
+        asteroid.x,
+        asteroid.y,
+        rotationY,
+        1, // scale = 1 (mesh already sized per category)
+        tintR,
+        tintG,
+        tintB,
+        flash,
+      );
+    }
+  }
+
+  /**
+   * Render the home base at its world position.
+   * Tints red when damaged, with subtle scale pulse.
+   */
+  renderHomeBase(homeBase: HomeBase, time: number): void {
+    const hpRatio = homeBase.maxHealth > 0
+      ? homeBase.health / homeBase.maxHealth
+      : 1;
+
+    // Interpolate from blue-white (full HP) to red (0 HP)
+    // At full HP: tint = [1, 1, 1] (no tint). At 0 HP: tint = [1, 0.3, 0.3]
+    const tintR = 1;
+    const tintG = 0.3 + hpRatio * 0.7;
+    const tintB = 0.3 + hpRatio * 0.7;
+
+    // Subtle scale pulse
+    const pulse = 1 + Math.sin(time * 2) * 0.02;
+
+    this.renderer.drawMeshTinted(
+      this.homeBaseHandle,
+      homeBase.x,
+      homeBase.y,
+      0, // no rotation
+      pulse,
+      tintR,
+      tintG,
+      tintB,
+      0, // no flash
+    );
+  }
+
+  /** Clean up all GPU resources */
+  dispose(): void {
+    const sizes = ['small', 'medium', 'large'] as const;
+    for (const size of sizes) {
+      for (const handle of this.asteroidHandles[size]) {
+        this.renderer.deleteMesh(handle);
+      }
+    }
+    this.renderer.deleteMesh(this.homeBaseHandle);
+  }
+}

--- a/src/rendering/Renderer3D.test.ts
+++ b/src/rendering/Renderer3D.test.ts
@@ -148,10 +148,14 @@ describe('Renderer3D', () => {
         // Should have set tint color, then reset it (2 calls)
         const uniform3fvCalls = (gl.uniform3fv as ReturnType<typeof vi.fn>).mock.calls;
         expect(uniform3fvCalls.length).toBe(2);
-        // First call: set tint
-        expect(uniform3fvCalls[0][1]).toEqual([0.8, 0.2, 0.1]);
-        // Second call: reset to white
-        expect(uniform3fvCalls[1][1]).toEqual([1, 1, 1]);
+        // First call: set tint (Float32Array)
+        expect(Array.from(uniform3fvCalls[0][1])).toEqual([
+          expect.closeTo(0.8, 4),
+          expect.closeTo(0.2, 4),
+          expect.closeTo(0.1, 4),
+        ]);
+        // Second call: reset to white (Float32Array)
+        expect(Array.from(uniform3fvCalls[1][1])).toEqual([1, 1, 1]);
 
         // Should have set flash, then reset it (2 calls)
         const uniform1fCalls = (gl.uniform1f as ReturnType<typeof vi.fn>).mock.calls;

--- a/src/rendering/Renderer3D.test.ts
+++ b/src/rendering/Renderer3D.test.ts
@@ -31,6 +31,7 @@ function createMockGL() {
     getProgramInfoLog: vi.fn(() => ''),
     useProgram: vi.fn(),
     getUniformLocation: vi.fn(() => ({ __loc: true })),
+    uniform1f: vi.fn(),
     uniform3fv: vi.fn(),
     uniformMatrix4fv: vi.fn(),
     enable: vi.fn(),
@@ -122,6 +123,41 @@ describe('Renderer3D', () => {
           expect.closeTo(0xcc / 255, 2),
           1
         );
+      });
+    });
+  });
+
+  describe('drawMeshTinted', () => {
+    it('sets tint and flash uniforms before drawing, then resets them', () => {
+      withMockRenderer((renderer, gl) => {
+        const mesh = renderer.uploadMesh({
+          positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+          colors: new Float32Array([1, 0, 0, 1, 0, 0, 1, 0, 0]),
+          indices: new Uint16Array([0, 1, 2]),
+        });
+
+        renderer.beginFrame(0, 0, 0, 1);
+
+        // Clear call counts to isolate drawMeshTinted calls
+        (gl.uniform3fv as ReturnType<typeof vi.fn>).mockClear();
+        (gl.uniform1f as ReturnType<typeof vi.fn>).mockClear();
+
+        renderer.drawMeshTinted(mesh, 10, 20, 0, 1, 0.8, 0.2, 0.1, 0.5);
+
+        // Should have set tint color, then reset it (2 calls)
+        const uniform3fvCalls = (gl.uniform3fv as ReturnType<typeof vi.fn>).mock.calls;
+        expect(uniform3fvCalls.length).toBe(2);
+        // First call: set tint
+        expect(uniform3fvCalls[0][1]).toEqual([0.8, 0.2, 0.1]);
+        // Second call: reset to white
+        expect(uniform3fvCalls[1][1]).toEqual([1, 1, 1]);
+
+        // Should have set flash, then reset it (2 calls)
+        const uniform1fCalls = (gl.uniform1f as ReturnType<typeof vi.fn>).mock.calls;
+        expect(uniform1fCalls.length).toBe(2);
+        expect(uniform1fCalls[0][1]).toBe(0.5);
+        expect(uniform1fCalls[1][1]).toBe(0);
       });
     });
   });

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -123,6 +123,10 @@ export class Renderer3D {
   private clearB = 0;
   private clearA = 1;
 
+  // Pre-allocated arrays for tint uniforms (avoid per-frame allocation)
+  private tintArray = new Float32Array([1, 1, 1]);
+  private defaultTint = new Float32Array([1, 1, 1]);
+
   // Current camera matrices (reused each frame)
   private projectionMatrix: Float32Array = mat4.identity();
   private viewMatrix: Float32Array = mat4.identity();
@@ -146,7 +150,7 @@ export class Renderer3D {
     gl.uniform3fv(this.uAmbient, AMBIENT);
 
     // Set default tint (white = no tint) and no flash
-    gl.uniform3fv(this.uTintColor, [1, 1, 1]);
+    gl.uniform3fv(this.uTintColor, this.defaultTint);
     gl.uniform1f(this.uDamageFlash, 0);
 
     // Enable depth testing
@@ -364,11 +368,14 @@ export class Renderer3D {
     flash: number,
   ): void {
     const { gl } = this;
-    gl.uniform3fv(this.uTintColor, [tintR, tintG, tintB]);
+    this.tintArray[0] = tintR;
+    this.tintArray[1] = tintG;
+    this.tintArray[2] = tintB;
+    gl.uniform3fv(this.uTintColor, this.tintArray);
     gl.uniform1f(this.uDamageFlash, flash);
     this.drawMesh(handle, worldX, worldY, rotationY, scaleVal);
     // Reset to defaults so subsequent drawMesh calls are unaffected
-    gl.uniform3fv(this.uTintColor, [1, 1, 1]);
+    gl.uniform3fv(this.uTintColor, this.defaultTint);
     gl.uniform1f(this.uDamageFlash, 0);
   }
 

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -34,14 +34,18 @@ in vec3 vWorldPos;
 
 uniform vec3 uLightDir;
 uniform vec3 uAmbient;
+uniform vec3 uTintColor;
+uniform float uDamageFlash;
 
 out vec4 fragColor;
 
 void main() {
   vec3 normal = normalize(vNormal);
   float diffuse = max(dot(normal, uLightDir), 0.0);
-  vec3 lit = vColor * (uAmbient + vec3(diffuse));
-  fragColor = vec4(lit, 1.0);
+  vec3 lit = vColor * uTintColor * (uAmbient + vec3(diffuse));
+  // Damage flash: mix toward white
+  vec3 finalColor = mix(lit, vec3(1.0), uDamageFlash);
+  fragColor = vec4(finalColor, 1.0);
 }
 `;
 
@@ -110,6 +114,8 @@ export class Renderer3D {
   private uModel: WebGLUniformLocation | null;
   private uLightDir: WebGLUniformLocation | null;
   private uAmbient: WebGLUniformLocation | null;
+  private uTintColor: WebGLUniformLocation | null;
+  private uDamageFlash: WebGLUniformLocation | null;
 
   // Clear color (defaults to transparent black)
   private clearR = 0;
@@ -132,10 +138,16 @@ export class Renderer3D {
     this.uModel = gl.getUniformLocation(program, 'uModel');
     this.uLightDir = gl.getUniformLocation(program, 'uLightDir');
     this.uAmbient = gl.getUniformLocation(program, 'uAmbient');
+    this.uTintColor = gl.getUniformLocation(program, 'uTintColor');
+    this.uDamageFlash = gl.getUniformLocation(program, 'uDamageFlash');
 
     // Set static uniforms
     gl.uniform3fv(this.uLightDir, LIGHT_DIR);
     gl.uniform3fv(this.uAmbient, AMBIENT);
+
+    // Set default tint (white = no tint) and no flash
+    gl.uniform3fv(this.uTintColor, [1, 1, 1]);
+    gl.uniform1f(this.uDamageFlash, 0);
 
     // Enable depth testing
     gl.enable(gl.DEPTH_TEST);
@@ -326,6 +338,38 @@ export class Renderer3D {
     gl.uniformMatrix4fv(this.uModel, false, model);
     gl.bindVertexArray(handle.vao);
     gl.drawElements(gl.TRIANGLES, handle.indexCount, gl.UNSIGNED_SHORT, 0);
+  }
+
+  /**
+   * Draw a mesh with tint color and damage flash.
+   * @param handle Mesh handle from uploadMesh
+   * @param worldX World X position
+   * @param worldY World Y position (maps to 3D Z)
+   * @param rotationY Rotation around the Y (up) axis in radians
+   * @param scaleVal Uniform scale factor
+   * @param tintR Tint color red component (0-1, default 1)
+   * @param tintG Tint color green component (0-1, default 1)
+   * @param tintB Tint color blue component (0-1, default 1)
+   * @param flash Damage flash intensity (0 = none, 1 = full white)
+   */
+  drawMeshTinted(
+    handle: MeshHandle,
+    worldX: number,
+    worldY: number,
+    rotationY: number,
+    scaleVal: number,
+    tintR: number,
+    tintG: number,
+    tintB: number,
+    flash: number,
+  ): void {
+    const { gl } = this;
+    gl.uniform3fv(this.uTintColor, [tintR, tintG, tintB]);
+    gl.uniform1f(this.uDamageFlash, flash);
+    this.drawMesh(handle, worldX, worldY, rotationY, scaleVal);
+    // Reset to defaults so subsequent drawMesh calls are unaffected
+    gl.uniform3fv(this.uTintColor, [1, 1, 1]);
+    gl.uniform1f(this.uDamageFlash, 0);
   }
 
   /** End the frame. Currently a no-op but reserved for future use. */


### PR DESCRIPTION
## Summary

Replaces the test cube placeholder with actual 3D rendering of asteroids and the home base. Asteroids render as position-seeded rocky meshes with rotation, damage flash, and mining darkening. The home base renders as a hexagonal platform that tints red when damaged.

## Changes

The implementation starts at the shader level: the fragment shader in `Renderer3D.ts` gains two new uniforms — `uTintColor` (vec3) for color tinting and `uDamageFlash` (float) for white flash effects. A new `drawMeshTinted()` method sets these uniforms per draw call, using pre-allocated Float32Arrays to avoid GC pressure in the hot path.

`EntityRenderer3D` is the entity render manager that sits between `main.ts` and `Renderer3D`. At init time, it pre-generates 30 asteroid mesh variants (10 per size category) and one home base mesh — all uploaded to GPU once. Each frame, it iterates entities with squared-distance culling, applies position-seeded Y-axis rotation, mining progress darkening, and damage flash. The home base gets HP-based red tinting and a subtle scale pulse.

In `main.ts`, the test cube is replaced with `EntityRenderer3D` calls that render asteroids from `world.entities` and the home base, using the same view radius calculation as the 2D layer for consistent culling.

## PRDs Completed

1. **prd-001** (frontend): Add tint/flash uniforms and `drawMeshTinted` to Renderer3D
2. **prd-002** (frontend): Create EntityRenderer3D and integrate into main.ts

## Test Coverage

- 13 new tests in `EntityRenderer3D.test.ts` covering mesh pool creation, culling, damage flash, mining darkening, rotation, home base tinting, pulse, and dispose
- 1 new test in `Renderer3D.test.ts` for `drawMeshTinted` uniform behavior
- All 603 tests pass, build succeeds

## Quality Gates

- [x] All tests pass (603/603)
- [x] TypeScript strict mode — no errors
- [x] Production build succeeds
- [x] Zero hot-path allocations (pre-allocated Float32Arrays for uniforms)
- [x] No runtime dependencies added

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2