### PR TITLE
3D entity rendering — player ship and enemies

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -128,6 +128,8 @@ let baseModeClickHandler: ((e: MouseEvent) => void) | null = null;
 let bossSystem: BossSystem = new BossSystem();
 /** Current boss reference during final_wave (null when no boss is active) */
 let currentBoss: Enemy | null = null;
+/** Last frame's thrust input — captured in update, used in render for 3D player glow */
+let lastThrust = 0;
 
 function showMainMenu() {
   gameState = 'menu';
@@ -650,6 +652,7 @@ const loop = new GameLoop({
 
     // Tank-style movement: A/D turn, W/S thrust along heading
     const { turn, thrust } = input.getTankInput();
+    lastThrust = thrust;
     const oldX = player.x;
     const oldY = player.y;
 
@@ -1161,6 +1164,24 @@ const loop = new GameLoop({
 
       // Render home base with HP-based red tinting and pulse
       entityRenderer3d.renderHomeBase(homeBase, player.survivalTime);
+
+      // Render enemies with subtype-specific 3D meshes and animations
+      entityRenderer3d.renderEnemies(
+        world.entities,
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
+      // Render player ship with banking and engine glow
+      entityRenderer3d.renderPlayer(
+        player.x,
+        player.y,
+        player.turnVelocity,
+        lastThrust,
+        player.survivalTime,
+      );
 
       renderer3d.endFrame();
     }

--- a/src/radar/BlipRenderer.ts
+++ b/src/radar/BlipRenderer.ts
@@ -268,20 +268,8 @@ export class BlipRenderer {
 
         ctx.restore();
       } else if (entity.type === 'enemy') {
-        const enemy = entity as Enemy;
-
-        // Faked glow: larger, lower-alpha circle behind the blip
-        ctx.globalAlpha = GLOW_ALPHA;
-        ctx.beginPath();
-        ctx.arc(screenX, screenY, currentSize * GLOW_RADIUS_MULT, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-        ctx.globalAlpha = 1;
-
-        // Main blip — subtype-specific shape
-        drawEnemyShape(ctx, screenX, screenY, currentSize, enemy);
-        ctx.fillStyle = color;
-        ctx.fill();
+        // Enemy shapes are rendered in 3D — skip 2D shape drawing.
+        // Labels still render below (2D overlay).
       } else {
         // Non-enemy, non-salvage entities (resource, etc.) — circle blip
         // Faked glow: larger, lower-alpha circle behind the blip

--- a/src/rendering/EntityRenderer3D.test.ts
+++ b/src/rendering/EntityRenderer3D.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EntityRenderer3D } from './EntityRenderer3D';
 import type { Renderer3D, MeshHandle } from './Renderer3D';
-import type { Asteroid, HomeBase, GameEntity } from '../entities/Entity';
-import { createAsteroid, createHomeBase } from '../entities/Entity';
+import type { Asteroid, Enemy, HomeBase, GameEntity } from '../entities/Entity';
+import { createAsteroid, createEnemy, createHomeBase, createBossEnemy } from '../entities/Entity';
 
 // ─── Mock Renderer ──────────────────────────────────────────────────────
 
@@ -14,6 +14,15 @@ function createMockRenderer() {
     worldY: number;
     rotationY: number;
     scale: number;
+    tintR: number;
+    tintG: number;
+    tintB: number;
+    flash: number;
+  }[] = [];
+
+  const drawMeshWithMatrixCalls: {
+    handle: MeshHandle;
+    modelMatrix: Float32Array;
     tintR: number;
     tintG: number;
     tintB: number;
@@ -37,10 +46,15 @@ function createMockRenderer() {
         drawMeshTintedCalls.push({ handle, worldX, worldY, rotationY, scale, tintR, tintG, tintB, flash });
       },
     ),
+    drawMeshWithMatrix: vi.fn(
+      (handle: MeshHandle, modelMatrix: Float32Array, tintR: number, tintG: number, tintB: number, flash: number) => {
+        drawMeshWithMatrixCalls.push({ handle, modelMatrix, tintR, tintG, tintB, flash });
+      },
+    ),
     deleteMesh: vi.fn(),
   } as unknown as Renderer3D;
 
-  return { renderer, drawMeshTintedCalls };
+  return { renderer, drawMeshTintedCalls, drawMeshWithMatrixCalls };
 }
 
 // ─── Test helpers ───────────────────────────────────────────────────────
@@ -50,16 +64,26 @@ function makeAsteroid(overrides: Partial<Asteroid> = {}): Asteroid {
   return { ...base, ...overrides };
 }
 
+function makeEnemy(overrides: Partial<Enemy> = {}): Enemy {
+  const base = createEnemy(50, 60, 'scout');
+  return { ...base, visible: true, ...overrides };
+}
+
+function makeBoss(overrides: Partial<Enemy> = {}): Enemy {
+  const base = createBossEnemy(100, 100);
+  return { ...base, visible: true, ...overrides };
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────
 
 describe('EntityRenderer3D', () => {
   describe('constructor', () => {
-    it('uploads 30 asteroid meshes (10 per size) and 1 home base mesh', () => {
+    it('uploads 30 asteroid meshes + 1 home base + 1 player + 4 enemy meshes = 36 uploads', () => {
       const { renderer } = createMockRenderer();
       const entityRenderer = new EntityRenderer3D(renderer);
 
-      // 10 small + 10 medium + 10 large + 1 home base = 31 uploads
-      expect(renderer.uploadMesh).toHaveBeenCalledTimes(31);
+      // 10 small + 10 medium + 10 large + 1 home base + 1 player + 4 enemies = 36
+      expect(renderer.uploadMesh).toHaveBeenCalledTimes(36);
 
       entityRenderer.dispose();
     });
@@ -178,7 +202,6 @@ describe('EntityRenderer3D', () => {
       entityRenderer.renderAsteroids(entities, 0, 0, 500, 5);
       const rotation5 = drawMeshTintedCalls[0].rotationY;
 
-      // Rotation should increase with time
       expect(rotation5).toBeGreaterThan(rotation0);
 
       entityRenderer.dispose();
@@ -222,7 +245,6 @@ describe('EntityRenderer3D', () => {
       const entityRenderer = new EntityRenderer3D(renderer);
 
       const homeBase = createHomeBase(0, 0);
-      // Full HP: tintG = 0.3 + 1.0*0.7 = 1.0, tintB = 1.0
 
       entityRenderer.renderHomeBase(homeBase, 0);
 
@@ -246,7 +268,6 @@ describe('EntityRenderer3D', () => {
       entityRenderer.renderHomeBase(homeBase, Math.PI / 4); // sin(PI/2) = 1
       const scalePeak = drawMeshTintedCalls[0].scale;
 
-      // Pulse should vary the scale slightly
       expect(scale0).toBeCloseTo(1.0, 1);
       expect(scalePeak).toBeCloseTo(1.02, 2);
 
@@ -254,15 +275,251 @@ describe('EntityRenderer3D', () => {
     });
   });
 
+  describe('renderPlayer', () => {
+    it('renders the player at the given world position', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderPlayer(100, 200, 0, 0, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+      // Model matrix encodes translation: x=100, z=200 (world Y maps to 3D Z)
+      const m = drawMeshWithMatrixCalls[0].modelMatrix;
+      expect(m[12]).toBeCloseTo(100, 1); // tx
+      expect(m[14]).toBeCloseTo(200, 1); // tz (world Y)
+
+      entityRenderer.dispose();
+    });
+
+    it('applies no flash by default', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderPlayer(0, 0, 0, 0, 0);
+
+      expect(drawMeshWithMatrixCalls[0].flash).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('increases tint brightness when thrusting forward', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // No thrust
+      entityRenderer.renderPlayer(0, 0, 0, 0, 0);
+      const noThrustG = drawMeshWithMatrixCalls[0].tintG;
+
+      drawMeshWithMatrixCalls.length = 0;
+
+      // Full thrust
+      entityRenderer.renderPlayer(0, 0, 0, 1, 0);
+      const fullThrustG = drawMeshWithMatrixCalls[0].tintG;
+
+      expect(fullThrustG).toBeGreaterThan(noThrustG);
+
+      entityRenderer.dispose();
+    });
+
+    it('does not boost tint when thrusting backward', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // Backward thrust (negative)
+      entityRenderer.renderPlayer(0, 0, 0, -1, 0);
+
+      // Should be same as no thrust (glow = max(0, thrust) * boost)
+      expect(drawMeshWithMatrixCalls[0].tintG).toBeCloseTo(1, 2);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies banking from turn velocity', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // No turn
+      entityRenderer.renderPlayer(0, 0, 0, 0, 0);
+      const noTurnMatrix = new Float32Array(drawMeshWithMatrixCalls[0].modelMatrix);
+
+      drawMeshWithMatrixCalls.length = 0;
+
+      // Turning right (positive turnVelocity)
+      entityRenderer.renderPlayer(0, 0, 3, 0, 0);
+      const turningMatrix = drawMeshWithMatrixCalls[0].modelMatrix;
+
+      // Matrices should differ (banking applied)
+      let different = false;
+      for (let j = 0; j < 16; j++) {
+        if (Math.abs(noTurnMatrix[j] - turningMatrix[j]) > 0.001) {
+          different = true;
+          break;
+        }
+      }
+      expect(different).toBe(true);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderEnemies', () => {
+    it('renders a scout enemy within view radius', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 30, y: 40, subtype: 'scout', vx: 1, vy: 0 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders different mesh handles for different subtypes', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 10, y: 10, subtype: 'scout' }),
+        makeEnemy({ x: 20, y: 20, subtype: 'brute' }),
+        makeEnemy({ x: 30, y: 30, subtype: 'ranged' }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(3);
+      // Each should use a different mesh handle
+      const handles = drawMeshWithMatrixCalls.map(c => c.handle);
+      expect(handles[0]).not.toBe(handles[1]);
+      expect(handles[1]).not.toBe(handles[2]);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls enemies outside view radius', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 2000, y: 2000, subtype: 'scout' }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 100, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive enemies', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 10, y: 10, active: false }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips invisible enemies (ghost blips are 2D)', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 10, y: 10, visible: false, ghostX: 10, ghostY: 10 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders enemies with no flash (Enemy type has no damageFlash)', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeEnemy({ x: 10, y: 10 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls[0].flash).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders boss with phase-based color shift at phase 2', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeBoss({ x: 10, y: 10, bossPhase: 2 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      // Phase 2: orange tint (tintR > 1, tintG < 1)
+      expect(drawMeshWithMatrixCalls[0].tintR).toBeGreaterThan(1);
+      expect(drawMeshWithMatrixCalls[0].tintG).toBeLessThan(1);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders boss with phase-based color shift at phase 3', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeBoss({ x: 10, y: 10, bossPhase: 3 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      // Phase 3: red tint (tintR high, tintB low)
+      expect(drawMeshWithMatrixCalls[0].tintR).toBeGreaterThan(1);
+      expect(drawMeshWithMatrixCalls[0].tintB).toBeLessThan(0.5);
+
+      entityRenderer.dispose();
+    });
+
+    it('boss has default white tint at phase 1', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeBoss({ x: 10, y: 10, bossPhase: 1 }),
+      ];
+
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls[0].tintR).toBe(1);
+      expect(drawMeshWithMatrixCalls[0].tintG).toBe(1);
+      expect(drawMeshWithMatrixCalls[0].tintB).toBe(1);
+
+      entityRenderer.dispose();
+    });
+  });
+
   describe('dispose', () => {
-    it('deletes all uploaded meshes', () => {
+    it('deletes all uploaded meshes including player and enemy handles', () => {
       const { renderer } = createMockRenderer();
       const entityRenderer = new EntityRenderer3D(renderer);
 
       entityRenderer.dispose();
 
-      // 30 asteroid + 1 home base = 31 deletions
-      expect(renderer.deleteMesh).toHaveBeenCalledTimes(31);
+      // 30 asteroid + 1 home base + 1 player + 4 enemies = 36 deletions
+      expect(renderer.deleteMesh).toHaveBeenCalledTimes(36);
     });
   });
 });

--- a/src/rendering/EntityRenderer3D.ts
+++ b/src/rendering/EntityRenderer3D.ts
@@ -1,14 +1,25 @@
 /**
- * Entity render manager for 3D mesh rendering of asteroids and home base.
+ * Entity render manager for 3D mesh rendering of game entities.
  *
- * Pre-generates a pool of asteroid mesh variants at init time (never in hot path).
+ * Pre-generates mesh pools at init time (never in hot path).
  * Each frame, iterates over active entities, culls by distance, and draws with
  * appropriate tint, rotation, and damage flash.
+ *
+ * Handles: asteroids, home base, player ship, enemies (scout/brute/ranged/boss).
  */
 
 import type { Renderer3D, MeshHandle } from './Renderer3D';
-import type { Asteroid, GameEntity, HomeBase } from '../entities/Entity';
-import { createAsteroidMesh, createHomeBaseMesh } from './meshes';
+import type { Asteroid, Enemy, GameEntity, HomeBase } from '../entities/Entity';
+import { mat4 } from './math3d';
+import {
+  createAsteroidMesh,
+  createHomeBaseMesh,
+  createPlayerMesh,
+  createScoutMesh,
+  createBruteMesh,
+  createRangedMesh,
+  createBossMesh,
+} from './meshes';
 
 // ─── Constants ──────────────────────────────────────────────────────────
 
@@ -22,13 +33,40 @@ const ROTATION_SPEED_RANGE = 0.3;
 /** Mining darkening: at full progress, color multiplied by this */
 const MINING_DARKEN_FACTOR = 0.5;
 
-/** Damage flash decay speed is handled by the game — we just read the value */
+/** Player banking: max roll angle in radians (~20 degrees) */
+const MAX_BANK_ANGLE = 0.35;
+
+/** Player banking: how much turnVelocity maps to roll (higher = more responsive) */
+const BANK_SENSITIVITY = 0.08;
+
+/** Player engine glow: tint boost when thrusting */
+const ENGINE_GLOW_BOOST = 0.3;
+
+/** Scout wobble: amplitude in radians */
+const SCOUT_WOBBLE_AMP = 0.15;
+
+/** Scout wobble: frequency multiplier */
+const SCOUT_WOBBLE_FREQ = 8;
+
+/** Brute rotation: slow constant Y rotation speed (rad/s) */
+const BRUTE_ROTATION_SPEED = 0.5;
+
+/** Ranged bobbing: amplitude in world units */
+const RANGED_BOB_AMP = 3;
+
+/** Ranged bobbing: frequency multiplier */
+const RANGED_BOB_FREQ = 3;
+
+/** Boss pulse: scale amplitude */
+const BOSS_PULSE_AMP = 0.08;
+
+/** Boss pulse: frequency multiplier */
+const BOSS_PULSE_FREQ = 2;
 
 // ─── Position hash for deterministic seeding ────────────────────────────
 
 /** Hash a position into a deterministic integer seed */
 function positionSeed(x: number, y: number): number {
-  // Large primes for spatial hashing, bitwise-or to integer
   return ((x * 73856093) ^ (y * 19349663)) | 0;
 }
 
@@ -46,6 +84,15 @@ export class EntityRenderer3D {
 
   // Home base mesh
   private homeBaseHandle: MeshHandle;
+
+  // Player mesh
+  private playerHandle: MeshHandle;
+
+  // Enemy meshes (one per subtype + boss)
+  private scoutHandle: MeshHandle;
+  private bruteHandle: MeshHandle;
+  private rangedHandle: MeshHandle;
+  private bossHandle: MeshHandle;
 
   constructor(renderer: Renderer3D) {
     this.renderer = renderer;
@@ -66,8 +113,16 @@ export class EntityRenderer3D {
     }
 
     // Pre-generate home base mesh
-    const homeBaseMesh = createHomeBaseMesh();
-    this.homeBaseHandle = renderer.uploadMesh(homeBaseMesh);
+    this.homeBaseHandle = renderer.uploadMesh(createHomeBaseMesh());
+
+    // Pre-generate player mesh
+    this.playerHandle = renderer.uploadMesh(createPlayerMesh());
+
+    // Pre-generate enemy meshes
+    this.scoutHandle = renderer.uploadMesh(createScoutMesh());
+    this.bruteHandle = renderer.uploadMesh(createBruteMesh());
+    this.rangedHandle = renderer.uploadMesh(createRangedMesh());
+    this.bossHandle = renderer.uploadMesh(createBossMesh());
   }
 
   /**
@@ -107,9 +162,9 @@ export class EntityRenderer3D {
 
       // Tint: start white (no tint), darken with mining progress
       const miningDarken = 1 - asteroid.miningProgress * MINING_DARKEN_FACTOR;
-      let tintR = miningDarken;
-      let tintG = miningDarken;
-      let tintB = miningDarken;
+      const tintR = miningDarken;
+      const tintG = miningDarken;
+      const tintB = miningDarken;
 
       // Damage flash: override tint toward white
       const flash = asteroid.damageFlash > 0 ? Math.min(asteroid.damageFlash, 1) : 0;
@@ -138,7 +193,6 @@ export class EntityRenderer3D {
       : 1;
 
     // Interpolate from blue-white (full HP) to red (0 HP)
-    // At full HP: tint = [1, 1, 1] (no tint). At 0 HP: tint = [1, 0.3, 0.3]
     const tintR = 1;
     const tintG = 0.3 + hpRatio * 0.7;
     const tintB = 0.3 + hpRatio * 0.7;
@@ -159,6 +213,156 @@ export class EntityRenderer3D {
     );
   }
 
+  /**
+   * Render the player ship at the given world position.
+   * The ship always points up (camera rotates the world). Banking animation
+   * tilts the ship based on turnVelocity. Engine glow tints brighter when thrusting.
+   *
+   * @param x Player world X
+   * @param y Player world Y
+   * @param turnVelocity Current turn velocity (rad/s, positive = clockwise)
+   * @param thrust Current thrust input (-1 to 1, 0 = no thrust)
+   * @param time Game time in seconds
+   */
+  renderPlayer(
+    x: number,
+    y: number,
+    turnVelocity: number,
+    thrust: number,
+    time: number,
+  ): void {
+    // Build model matrix: translate to world position, then bank (roll on Z)
+    // The camera already handles world rotation so the ship always faces up (+Z in mesh space)
+    let model = mat4.translate(mat4.identity(), x, 0, y);
+
+    // Banking: roll proportional to turnVelocity, clamped
+    const bankAngle = Math.max(-MAX_BANK_ANGLE, Math.min(MAX_BANK_ANGLE, -turnVelocity * BANK_SENSITIVITY));
+    if (bankAngle !== 0) {
+      model = mat4.rotateZ(model, bankAngle);
+    }
+
+    // Engine glow: brighten tint when thrusting (thrust > 0 = forward)
+    const thrustAmount = Math.max(0, thrust);
+    const glow = thrustAmount * ENGINE_GLOW_BOOST;
+    const tintR = 1 + glow * 0.3; // slight warm shift when thrusting
+    const tintG = 1 + glow;
+    const tintB = 1 + glow * 0.8;
+
+    this.renderer.drawMeshWithMatrix(
+      this.playerHandle,
+      model,
+      Math.min(tintR, 1.5),
+      Math.min(tintG, 1.5),
+      Math.min(tintB, 1.5),
+      0, // no flash
+    );
+  }
+
+  /**
+   * Render all visible enemies from the entity list.
+   * Each subtype has a distinct mesh and animation:
+   * - Scout: faces movement direction, slight wobble
+   * - Brute: faces movement direction, slow constant rotation
+   * - Ranged: faces movement direction, gentle bobbing
+   * - Boss: large hexagonal prism, pulsing scale, phase-based color shift
+   *
+   * Ghost blips and labels remain 2D overlays (handled by BlipRenderer).
+   */
+  renderEnemies(
+    entities: readonly GameEntity[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      if (entity.type !== 'enemy' || !entity.active || !entity.visible) continue;
+
+      const enemy = entity as Enemy;
+
+      // Visibility culling
+      const dx = enemy.x - playerX;
+      const dy = enemy.y - playerY;
+      const distSq = dx * dx + dy * dy;
+      if (distSq > viewRadiusSq) continue;
+
+      // Heading from velocity: atan2(vy, vx) maps to Y-axis rotation in 3D
+      // In our 3D space: world X = 3D X, world Y (2D) = 3D Z
+      // Mesh faces +Z, so we rotate by -atan2(vx, vy) to point along velocity
+      const heading = (enemy.vx !== 0 || enemy.vy !== 0)
+        ? -Math.atan2(enemy.vx, enemy.vy)
+        : 0;
+
+      if (enemy.isBoss) {
+        this.renderBoss(enemy, heading, time);
+      } else if (enemy.subtype === 'scout') {
+        this.renderScout(enemy, heading, time);
+      } else if (enemy.subtype === 'brute') {
+        this.renderBrute(enemy, heading, time);
+      } else {
+        this.renderRanged(enemy, heading, time);
+      }
+    }
+  }
+
+  private renderScout(enemy: Enemy, heading: number, time: number): void {
+    let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
+    model = mat4.rotateY(model, heading);
+
+    // Slight wobble on Z-axis
+    const wobble = Math.sin(time * SCOUT_WOBBLE_FREQ) * SCOUT_WOBBLE_AMP;
+    model = mat4.rotateZ(model, wobble);
+
+    this.renderer.drawMeshWithMatrix(this.scoutHandle, model, 1, 1, 1, 0);
+  }
+
+  private renderBrute(enemy: Enemy, heading: number, time: number): void {
+    let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
+    // Face movement direction + slow constant rotation
+    model = mat4.rotateY(model, heading + time * BRUTE_ROTATION_SPEED);
+
+    this.renderer.drawMeshWithMatrix(this.bruteHandle, model, 1, 1, 1, 0);
+  }
+
+  private renderRanged(enemy: Enemy, heading: number, time: number): void {
+    // Gentle bobbing: translate Y up/down
+    const bob = Math.sin(time * RANGED_BOB_FREQ) * RANGED_BOB_AMP;
+    let model = mat4.translate(mat4.identity(), enemy.x, bob, enemy.y);
+    model = mat4.rotateY(model, heading);
+
+    this.renderer.drawMeshWithMatrix(this.rangedHandle, model, 1, 1, 1, 0);
+  }
+
+  private renderBoss(enemy: Enemy, heading: number, time: number): void {
+    // Pulsing scale
+    const pulse = 1 + Math.sin(time * BOSS_PULSE_FREQ) * BOSS_PULSE_AMP;
+    let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
+    model = mat4.rotateY(model, heading);
+    model = mat4.scale(model, pulse, pulse, pulse);
+
+    // Phase-based color shift:
+    // Phase 1: white tint (default)
+    // Phase 2: orange tint
+    // Phase 3: red tint
+    let tintR = 1;
+    let tintG = 1;
+    let tintB = 1;
+    if (enemy.bossPhase >= 3) {
+      tintR = 1.3;
+      tintG = 0.5;
+      tintB = 0.4;
+    } else if (enemy.bossPhase >= 2) {
+      tintR = 1.2;
+      tintG = 0.8;
+      tintB = 0.5;
+    }
+
+    this.renderer.drawMeshWithMatrix(this.bossHandle, model, tintR, tintG, tintB, 0);
+  }
+
   /** Clean up all GPU resources */
   dispose(): void {
     const sizes = ['small', 'medium', 'large'] as const;
@@ -168,5 +372,10 @@ export class EntityRenderer3D {
       }
     }
     this.renderer.deleteMesh(this.homeBaseHandle);
+    this.renderer.deleteMesh(this.playerHandle);
+    this.renderer.deleteMesh(this.scoutHandle);
+    this.renderer.deleteMesh(this.bruteHandle);
+    this.renderer.deleteMesh(this.rangedHandle);
+    this.renderer.deleteMesh(this.bossHandle);
   }
 }

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -379,6 +379,33 @@ export class Renderer3D {
     gl.uniform1f(this.uDamageFlash, 0);
   }
 
+  /**
+   * Draw a mesh with a pre-built model matrix, tint color, and damage flash.
+   * Use this when you need arbitrary transforms (banking, bobbing) that
+   * drawMesh/drawMeshTinted cannot express.
+   */
+  drawMeshWithMatrix(
+    handle: MeshHandle,
+    modelMatrix: Float32Array,
+    tintR: number,
+    tintG: number,
+    tintB: number,
+    flash: number,
+  ): void {
+    const { gl } = this;
+    this.tintArray[0] = tintR;
+    this.tintArray[1] = tintG;
+    this.tintArray[2] = tintB;
+    gl.uniform3fv(this.uTintColor, this.tintArray);
+    gl.uniform1f(this.uDamageFlash, flash);
+    gl.uniformMatrix4fv(this.uModel, false, modelMatrix);
+    gl.bindVertexArray(handle.vao);
+    gl.drawElements(gl.TRIANGLES, handle.indexCount, gl.UNSIGNED_SHORT, 0);
+    // Reset to defaults
+    gl.uniform3fv(this.uTintColor, this.defaultTint);
+    gl.uniform1f(this.uDamageFlash, 0);
+  }
+
   /** End the frame. Currently a no-op but reserved for future use. */
   endFrame(): void {
     // Reserved for future batch finalization, post-processing, etc.


### PR DESCRIPTION
## Summary

Extends the 3D WebGL2 renderer to render the player ship and all enemy types as 3D meshes with subtype-specific animations. This is WI-005 in the 3D entity rendering feature branch, building on the asteroid and home base rendering from WI-004.

## Changes

The work starts in `Renderer3D.ts` with a new `drawMeshWithMatrix()` method that accepts a pre-built model matrix instead of just Y-rotation. This enables arbitrary transforms like banking (Z-roll) and bobbing (Y-translate) that the simpler `drawMeshTinted()` cannot express.

`EntityRenderer3D.ts` is then extended to upload player, scout, brute, ranged, and boss meshes at init time (alongside the existing asteroid and home base meshes). Two new render methods are added:

- **`renderPlayer()`** — draws the player ship at screen center with banking animation (Z-axis roll proportional to `turnVelocity`) and engine glow (tint boost when thrusting forward). The ship always points up since the camera rotates the world.

- **`renderEnemies()`** — iterates all visible enemies, culls by distance, and draws each with its subtype mesh. All enemies face their movement direction via `atan2(vx, vy)`. Subtype-specific animations:
  - Scout: slight Z-axis wobble
  - Brute: slow constant Y rotation layered on top of heading
  - Ranged: gentle Y-axis bobbing (hovering feel)
  - Boss: pulsing scale animation + phase-based color shift (white at phase 1, orange at phase 2, red at phase 3)

In `main.ts`, the 3D render block now calls both new methods, passing player state (position, turnVelocity, thrust) and entity data. A `lastThrust` variable captures the thrust input during update for render-time access.

Finally, `BlipRenderer.ts` has its 2D enemy shape rendering removed (glow circles + filled shapes), since enemies are now 3D. Ghost blips for invisible enemies and resolution-level labels (S/B/R/BOSS) remain as 2D overlays — they are radar artifacts, not world objects.

## PRDs Completed
1. **prd-001**: Add `drawMeshWithMatrix` to Renderer3D + player/enemy render methods to EntityRenderer3D
2. **prd-002**: Wire 3D rendering in main.ts and clean up BlipRenderer

## Test Coverage
- 33 tests for EntityRenderer3D (up from 14) covering player rendering, enemy subtypes, culling, animations, boss phases
- 6 tests for Renderer3D (unchanged)
- Full suite: 617 tests passing

## Quality Gates
- Tests: 617/617 passing
- TypeScript: clean (`tsc --noEmit`)
- Build: clean (`npm run build`)
- Lint: no-op (not configured)

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2