### PR TITLE
3D entity rendering: bots, salvage, projectiles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1174,6 +1174,44 @@ const loop = new GameLoop({
         player.survivalTime,
       );
 
+      // Render salvage as rotating 3D diamonds
+      entityRenderer3d.renderSalvage(
+        world.entities,
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
+      // Render mining bots as 3D icospheres
+      entityRenderer3d.renderMiningBots(
+        miningBotSystem.getBots(),
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
+      // Render combat bots as 3D chevrons with lifetime pulse
+      entityRenderer3d.renderCombatBots(
+        combatBotSystem.bots,
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
+      // Render all projectile types as 3D shapes
+      entityRenderer3d.renderProjectiles(
+        combatSystem.projectiles,
+        combatBotSystem.botProjectiles,
+        abilitySystem.missiles,
+        player.x,
+        player.y,
+        viewRadius3d,
+        player.survivalTime,
+      );
+
       // Render player ship with banking and engine glow
       entityRenderer3d.renderPlayer(
         player.x,

--- a/src/radar/BlipRenderer.ts
+++ b/src/radar/BlipRenderer.ts
@@ -1,4 +1,4 @@
-import { GameEntity, Enemy, Salvage, Asteroid } from '../entities/Entity';
+import { GameEntity, Enemy, Asteroid } from '../entities/Entity';
 import { getTheme } from '../themes/theme';
 
 
@@ -91,6 +91,14 @@ function drawEnemyShape(
   }
 }
 
+/**
+ * BlipRenderer — reduced to ghost-blips and labels only.
+ *
+ * Entity shapes (asteroids, enemies, salvage) are rendered in 3D by EntityRenderer3D.
+ * This renderer handles:
+ * - Ghost blips for invisible enemies with last-known positions
+ * - Resolution labels (S/M/L for asteroids, S/B/R/BOSS for enemies, S for salvage)
+ */
 export class BlipRenderer {
   private time = 0;
 
@@ -144,11 +152,10 @@ export class BlipRenderer {
 
       let currentSize = size;
 
-      // Enemy subtype sizes, colors, and effects
+      // Enemy subtype sizes and colors (for label positioning)
       if (entity.type === 'enemy') {
         const enemy = entity as Enemy;
         if (enemy.isBoss) {
-          // Boss: large pulsing hexagon
           currentSize = (8 + Math.sin(this.time * 3) * 2) * 2;
           color = themeColors.enemyBoss;
         } else if (enemy.subtype === 'scout') {
@@ -158,56 +165,21 @@ export class BlipRenderer {
           currentSize = 7 + Math.sin(this.time * 2) * 2;
           color = themeColors.enemyBrute;
         } else {
-          // ranged: steady medium diamond
           currentSize = 4;
           color = themeColors.enemyRanged;
         }
       }
 
-      // Dropoffs are rendered in full by main.ts — skip blip
+      // Dropoffs are rendered in full by main.ts — skip
       if (entity.type === 'dropoff') continue;
 
-      // Asteroids: irregular circle, size varies by asteroid size category
+      // Asteroids: rendered in 3D — only labels remain here
       if (entity.type === 'asteroid') {
         const asteroid = entity as Asteroid;
         const asteroidRadius = asteroid.size === 'small' ? 4
           : asteroid.size === 'medium' ? 7
           : 10;
 
-        // Faked glow behind the asteroid
-        ctx.globalAlpha = GLOW_ALPHA;
-        ctx.beginPath();
-        ctx.arc(screenX, screenY, asteroidRadius * GLOW_RADIUS_MULT, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-        ctx.globalAlpha = 1;
-
-        // Irregular polygon shape (6 vertices with jitter based on position for consistency)
-        ctx.beginPath();
-        const vertices = 6;
-        for (let v = 0; v < vertices; v++) {
-          const angle = (v / vertices) * Math.PI * 2;
-          // Use position-based seed for consistent jitter per asteroid
-          const jitter = 0.7 + 0.3 * Math.abs(Math.sin(asteroid.x * 13.7 + asteroid.y * 7.3 + v * 2.1));
-          const r = asteroidRadius * jitter;
-          const px = screenX + Math.cos(angle) * r;
-          const py = screenY + Math.sin(angle) * r;
-          if (v === 0) ctx.moveTo(px, py);
-          else ctx.lineTo(px, py);
-        }
-        ctx.closePath();
-        ctx.fillStyle = color;
-        ctx.fill();
-
-        // Damage flash overlay
-        if (asteroid.damageFlash > 0) {
-          ctx.globalAlpha = Math.min(asteroid.damageFlash / 0.15, 1);
-          ctx.fillStyle = '#ffffff';
-          ctx.fill();
-          ctx.globalAlpha = 1;
-        }
-
-        // Resolution label for asteroids (S/M/L)
         if (resolutionLevel >= 2) {
           ctx.save();
           if (worldRotation) {
@@ -225,53 +197,10 @@ export class BlipRenderer {
         continue;
       }
 
-      // Salvage: pulsing diamond with aura (skip if already towed — rendered by tow rope system)
-      if (entity.type === 'salvage') {
-        const salvage = entity as Salvage;
-        if (salvage.towedByPlayer) continue;
-
-        const pulse = 1 + Math.sin(this.time * 4) * 0.3;
-        const auraSize = currentSize + 8 + Math.sin(this.time * 3) * 3;
-        ctx.globalAlpha = 0.12 + Math.sin(this.time * 3) * 0.04;
-        ctx.beginPath();
-        ctx.arc(screenX, screenY, auraSize, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-        ctx.globalAlpha = 1;
-
-        // Faked glow behind the diamond
-        ctx.globalAlpha = GLOW_ALPHA;
-        ctx.beginPath();
-        const glowS = currentSize * pulse * GLOW_RADIUS_MULT;
-        ctx.arc(screenX, screenY, glowS, 0, Math.PI * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-        ctx.globalAlpha = 1;
-
-        // Diamond shape — needs save/restore for translate+rotate
-        ctx.save();
-        ctx.translate(screenX, screenY);
-        ctx.rotate(Math.PI / 4);
-        const s = currentSize * pulse;
-        ctx.beginPath();
-        ctx.rect(-s, -s, s * 2, s * 2);
-        ctx.fillStyle = color;
-        ctx.fill();
-
-        // Damage flash overlay — white flash when recently hit
-        if (salvage.damageFlash > 0) {
-          ctx.globalAlpha = Math.min(salvage.damageFlash / 0.15, 1);
-          ctx.fillStyle = '#ffffff';
-          ctx.fill();
-          ctx.globalAlpha = 1;
-        }
-
-        ctx.restore();
-      } else if (entity.type === 'enemy') {
-        // Enemy shapes are rendered in 3D — skip 2D shape drawing.
-        // Labels still render below (2D overlay).
-      } else {
-        // Non-enemy, non-salvage entities (resource, etc.) — circle blip
+      // Salvage: rendered in 3D — skip shape drawing (labels handled below)
+      // Enemy: rendered in 3D — skip shape drawing (labels handled below)
+      // Resource: still render as 2D circle (no 3D mesh yet)
+      if (entity.type === 'resource') {
         // Faked glow: larger, lower-alpha circle behind the blip
         ctx.globalAlpha = GLOW_ALPHA;
         ctx.beginPath();

--- a/src/rendering/EntityRenderer3D.test.ts
+++ b/src/rendering/EntityRenderer3D.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EntityRenderer3D } from './EntityRenderer3D';
 import type { Renderer3D, MeshHandle } from './Renderer3D';
-import type { Asteroid, Enemy, HomeBase, GameEntity } from '../entities/Entity';
-import { createAsteroid, createEnemy, createHomeBase, createBossEnemy } from '../entities/Entity';
+import type { Asteroid, Enemy, HomeBase, GameEntity, Salvage, Projectile } from '../entities/Entity';
+import { createAsteroid, createEnemy, createHomeBase, createBossEnemy, createSalvage } from '../entities/Entity';
+import type { MiningBot } from '../systems/MiningBotSystem';
+import { MiningBotState } from '../systems/MiningBotSystem';
+import type { CombatBot } from '../systems/CombatBotSystem';
+import { CombatBotState } from '../systems/CombatBotSystem';
+import type { Missile } from '../systems/AbilitySystem';
 
 // ─── Mock Renderer ──────────────────────────────────────────────────────
 
@@ -78,12 +83,12 @@ function makeBoss(overrides: Partial<Enemy> = {}): Enemy {
 
 describe('EntityRenderer3D', () => {
   describe('constructor', () => {
-    it('uploads 30 asteroid meshes + 1 home base + 1 player + 4 enemy meshes = 36 uploads', () => {
+    it('uploads 30 asteroid + 1 home base + 1 player + 4 enemy + 2 bot + 1 salvage + 1 projectile = 40 meshes', () => {
       const { renderer } = createMockRenderer();
       const entityRenderer = new EntityRenderer3D(renderer);
 
-      // 10 small + 10 medium + 10 large + 1 home base + 1 player + 4 enemies = 36
-      expect(renderer.uploadMesh).toHaveBeenCalledTimes(36);
+      // 10 small + 10 medium + 10 large + 1 home base + 1 player + 4 enemies + 2 bots + 1 salvage + 1 projectile = 40
+      expect(renderer.uploadMesh).toHaveBeenCalledTimes(40);
 
       entityRenderer.dispose();
     });
@@ -511,15 +516,368 @@ describe('EntityRenderer3D', () => {
     });
   });
 
+  describe('renderMiningBots', () => {
+    function makeMiningBot(overrides: Partial<MiningBot> = {}): MiningBot {
+      return {
+        x: 50, y: 60, vx: 0, vy: 0, angle: 0,
+        targetAsteroid: null, state: MiningBotState.Mining,
+        miningProgress: 0, miningRate: 1, lifetime: 30,
+        active: true, aggroTimer: 5, energyAccum: 0,
+        energyTextTimer: 0, slotIndex: 0,
+        ...overrides,
+      };
+    }
+
+    it('renders active mining bots within view radius', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeMiningBot({ x: 30, y: 40 })];
+      entityRenderer.renderMiningBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(1);
+      expect(drawMeshTintedCalls[0].worldX).toBe(30);
+      expect(drawMeshTintedCalls[0].worldY).toBe(40);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls mining bots outside view radius', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeMiningBot({ x: 2000, y: 2000 })];
+      entityRenderer.renderMiningBots(bots, 0, 0, 100, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive mining bots', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeMiningBot({ active: false })];
+      entityRenderer.renderMiningBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies time-based rotation when mining', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeMiningBot({ state: MiningBotState.Mining })];
+      entityRenderer.renderMiningBots(bots, 0, 0, 500, 0);
+      const rot0 = drawMeshTintedCalls[0].rotationY;
+
+      drawMeshTintedCalls.length = 0;
+      entityRenderer.renderMiningBots(bots, 0, 0, 500, 5);
+      const rot5 = drawMeshTintedCalls[0].rotationY;
+
+      expect(rot5).toBeGreaterThan(rot0);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderCombatBots', () => {
+    function makeCombatBot(overrides: Partial<CombatBot> = {}): CombatBot {
+      return {
+        x: 50, y: 60, vx: 1, vy: 0, angle: 0,
+        state: CombatBotState.SeekingEnemy, targetEnemy: null,
+        targetX: 100, targetY: 100,
+        health: 30, maxHealth: 30, damage: 4,
+        fireRate: 1.5, fireTimer: 0, range: 200,
+        lifetime: 20, maxLifetime: 20,
+        active: true, slotIndex: 0,
+        ...overrides,
+      };
+    }
+
+    it('renders active combat bots within view radius', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeCombatBot({ x: 30, y: 40 })];
+      entityRenderer.renderCombatBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls combat bots outside view radius', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeCombatBot({ x: 2000, y: 2000 })];
+      entityRenderer.renderCombatBots(bots, 0, 0, 100, 1.0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive combat bots', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [makeCombatBot({ active: false })];
+      entityRenderer.renderCombatBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('dims tint when combat bot lifetime is low', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // Full lifetime
+      const freshBots = [makeCombatBot({ lifetime: 20, maxLifetime: 20 })];
+      entityRenderer.renderCombatBots(freshBots, 0, 0, 500, 0);
+      const freshTint = drawMeshWithMatrixCalls[0].tintR;
+
+      drawMeshWithMatrixCalls.length = 0;
+
+      // Nearly expired
+      const dyingBots = [makeCombatBot({ lifetime: 1, maxLifetime: 20 })];
+      entityRenderer.renderCombatBots(dyingBots, 0, 0, 500, 0);
+      const dyingTint = drawMeshWithMatrixCalls[0].tintR;
+
+      expect(dyingTint).toBeLessThan(freshTint);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderSalvage', () => {
+    function makeSalvageEntity(overrides: Partial<Salvage> = {}): Salvage {
+      const base = createSalvage(50, 60);
+      return { ...base, ...overrides };
+    }
+
+    it('renders active visible salvage as rotating diamonds', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity({ x: 30, y: 40 })];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(1);
+      expect(drawMeshTintedCalls[0].worldX).toBe(30);
+      expect(drawMeshTintedCalls[0].worldY).toBe(40);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls salvage outside view radius', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity({ x: 2000, y: 2000 })];
+      entityRenderer.renderSalvage(entities, 0, 0, 100, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive salvage', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity({ active: false })];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips invisible salvage', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity({ visible: false })];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('applies damage flash when damageFlash > 0', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity({ damageFlash: 0.5 })];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls[0].flash).toBeCloseTo(0.5, 1);
+
+      entityRenderer.dispose();
+    });
+
+    it('rotates based on time', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [makeSalvageEntity()];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 0);
+      const rot0 = drawMeshTintedCalls[0].rotationY;
+
+      drawMeshTintedCalls.length = 0;
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 5);
+      const rot5 = drawMeshTintedCalls[0].rotationY;
+
+      expect(rot5).toBeGreaterThan(rot0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips non-salvage entities', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20 }),
+        makeEnemy({ x: 30, y: 40 }),
+      ];
+      entityRenderer.renderSalvage(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('renderProjectiles', () => {
+    function makeProjectile(overrides: Partial<Projectile> = {}): Projectile {
+      return {
+        x: 50, y: 60, vx: 0, vy: -100,
+        damage: 8, active: true, lifetime: 2,
+        ...overrides,
+      };
+    }
+
+    function makeMissile(overrides: Partial<Missile> = {}): Missile {
+      return {
+        x: 50, y: 60, vx: 0, vy: -100,
+        speed: 200, damage: 20, lifetime: 5,
+        turnRate: 3, active: true,
+        ...overrides,
+      };
+    }
+
+    it('renders active enemy projectiles with red tint', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [makeProjectile()], [], [], 0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+      // Red tint: R > G and R > B
+      expect(drawMeshWithMatrixCalls[0].tintR).toBeGreaterThan(drawMeshWithMatrixCalls[0].tintG);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders combat bot projectiles with blue tint', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [], [makeProjectile()], [], 0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+      // Blue tint: B > R
+      expect(drawMeshWithMatrixCalls[0].tintB).toBeGreaterThan(drawMeshWithMatrixCalls[0].tintR);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders homing missiles with orange tint', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [], [], [makeMissile()], 0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(1);
+      // Orange: R > B
+      expect(drawMeshWithMatrixCalls[0].tintR).toBeGreaterThan(drawMeshWithMatrixCalls[0].tintB);
+
+      entityRenderer.dispose();
+    });
+
+    it('culls projectiles outside view radius', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [makeProjectile({ x: 2000, y: 2000 })],
+        [makeProjectile({ x: 2000, y: 2000 })],
+        [makeMissile({ x: 2000, y: 2000 })],
+        0, 0, 100, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('skips inactive projectiles', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [makeProjectile({ active: false })],
+        [makeProjectile({ active: false })],
+        [makeMissile({ active: false })],
+        0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('renders all three projectile types simultaneously', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [makeProjectile({ x: 10, y: 10 })],
+        [makeProjectile({ x: 20, y: 20 })],
+        [makeMissile({ x: 30, y: 30 })],
+        0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls.length).toBe(3);
+
+      entityRenderer.dispose();
+    });
+  });
+
   describe('dispose', () => {
-    it('deletes all uploaded meshes including player and enemy handles', () => {
+    it('deletes all uploaded meshes including bots, salvage, and projectile handles', () => {
       const { renderer } = createMockRenderer();
       const entityRenderer = new EntityRenderer3D(renderer);
 
       entityRenderer.dispose();
 
-      // 30 asteroid + 1 home base + 1 player + 4 enemies = 36 deletions
-      expect(renderer.deleteMesh).toHaveBeenCalledTimes(36);
+      // 30 asteroid + 1 home base + 1 player + 4 enemies + 2 bots + 1 salvage + 1 projectile = 40
+      expect(renderer.deleteMesh).toHaveBeenCalledTimes(40);
     });
   });
 });

--- a/src/rendering/EntityRenderer3D.ts
+++ b/src/rendering/EntityRenderer3D.ts
@@ -9,7 +9,11 @@
  */
 
 import type { Renderer3D, MeshHandle } from './Renderer3D';
-import type { Asteroid, Enemy, GameEntity, HomeBase } from '../entities/Entity';
+import type { Asteroid, Enemy, GameEntity, HomeBase, Projectile, Salvage } from '../entities/Entity';
+import type { MiningBot } from '../systems/MiningBotSystem';
+import { MiningBotState } from '../systems/MiningBotSystem';
+import type { CombatBot } from '../systems/CombatBotSystem';
+import type { Missile } from '../systems/AbilitySystem';
 import { mat4 } from './math3d';
 import {
   createAsteroidMesh,
@@ -19,6 +23,10 @@ import {
   createBruteMesh,
   createRangedMesh,
   createBossMesh,
+  createMiningBotMesh,
+  createCombatBotMesh,
+  createSalvageMesh,
+  createProjectileMesh,
 } from './meshes';
 
 // ─── Constants ──────────────────────────────────────────────────────────
@@ -63,6 +71,33 @@ const BOSS_PULSE_AMP = 0.08;
 /** Boss pulse: frequency multiplier */
 const BOSS_PULSE_FREQ = 2;
 
+/** Mining bot orbit rotation speed (rad/s) */
+const MINING_BOT_SPIN_SPEED = 3;
+
+/** Combat bot lifetime pulse frequency */
+const COMBAT_BOT_PULSE_FREQ = 4;
+
+/** Combat bot lifetime pulse: minimum tint multiplier when near expiry */
+const COMBAT_BOT_PULSE_DIM = 0.4;
+
+/** Salvage rotation speed (rad/s) */
+const SALVAGE_ROTATION_SPEED = 1.5;
+
+/** Salvage pulse amplitude */
+const SALVAGE_PULSE_AMP = 0.15;
+
+/** Salvage pulse frequency */
+const SALVAGE_PULSE_FREQ = 3;
+
+/** Enemy projectile scale */
+const ENEMY_PROJ_SCALE = 1.0;
+
+/** Combat bot projectile scale (tiny) */
+const COMBAT_BOT_PROJ_SCALE = 0.5;
+
+/** Homing missile scale (larger) */
+const HOMING_MISSILE_SCALE = 1.5;
+
 // ─── Position hash for deterministic seeding ────────────────────────────
 
 /** Hash a position into a deterministic integer seed */
@@ -94,6 +129,14 @@ export class EntityRenderer3D {
   private rangedHandle: MeshHandle;
   private bossHandle: MeshHandle;
 
+  // Bot meshes
+  private miningBotHandle: MeshHandle;
+  private combatBotHandle: MeshHandle;
+
+  // Salvage and projectile meshes
+  private salvageHandle: MeshHandle;
+  private projectileHandle: MeshHandle;
+
   constructor(renderer: Renderer3D) {
     this.renderer = renderer;
 
@@ -123,6 +166,14 @@ export class EntityRenderer3D {
     this.bruteHandle = renderer.uploadMesh(createBruteMesh());
     this.rangedHandle = renderer.uploadMesh(createRangedMesh());
     this.bossHandle = renderer.uploadMesh(createBossMesh());
+
+    // Pre-generate bot meshes
+    this.miningBotHandle = renderer.uploadMesh(createMiningBotMesh());
+    this.combatBotHandle = renderer.uploadMesh(createCombatBotMesh());
+
+    // Pre-generate salvage and projectile meshes
+    this.salvageHandle = renderer.uploadMesh(createSalvageMesh());
+    this.projectileHandle = renderer.uploadMesh(createProjectileMesh());
   }
 
   /**
@@ -363,6 +414,221 @@ export class EntityRenderer3D {
     this.renderer.drawMeshWithMatrix(this.bossHandle, model, tintR, tintG, tintB, 0);
   }
 
+  /**
+   * Render all active mining bots as 3D icospheres.
+   * Bots in Mining state spin around their orbit angle.
+   * Bots in Deploying state face their movement direction.
+   */
+  renderMiningBots(
+    bots: readonly MiningBot[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    for (let i = 0; i < bots.length; i++) {
+      const bot = bots[i];
+      if (!bot.active) continue;
+
+      // Visibility culling
+      const dx = bot.x - playerX;
+      const dy = bot.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      // Rotation: spinning when mining, heading-based when deploying
+      const rotY = bot.state === MiningBotState.Mining
+        ? time * MINING_BOT_SPIN_SPEED
+        : -Math.atan2(bot.vx, bot.vy);
+
+      this.renderer.drawMeshTinted(
+        this.miningBotHandle,
+        bot.x,
+        bot.y,
+        rotY,
+        1,
+        1, 1, 1, // white tint (no tint)
+        0, // no flash
+      );
+    }
+  }
+
+  /**
+   * Render all active combat bots as 3D chevrons.
+   * Facing movement direction. Lifetime-based pulsing: brighter when fresh, dimmer near expiry.
+   */
+  renderCombatBots(
+    bots: readonly CombatBot[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    for (let i = 0; i < bots.length; i++) {
+      const bot = bots[i];
+      if (!bot.active) continue;
+
+      // Visibility culling
+      const dx = bot.x - playerX;
+      const dy = bot.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      // Heading from velocity
+      const heading = (bot.vx !== 0 || bot.vy !== 0)
+        ? -Math.atan2(bot.vx, bot.vy)
+        : 0;
+
+      // Lifetime-based pulse: bots near expiry dim and pulse faster
+      const lifetimeRatio = bot.maxLifetime > 0 ? bot.lifetime / bot.maxLifetime : 1;
+      const baseBrightness = COMBAT_BOT_PULSE_DIM + (1 - COMBAT_BOT_PULSE_DIM) * lifetimeRatio;
+      const pulseSpeed = COMBAT_BOT_PULSE_FREQ * (2 - lifetimeRatio); // faster when dying
+      const pulse = baseBrightness + Math.sin(time * pulseSpeed) * 0.1 * (1 - lifetimeRatio);
+
+      const tint = Math.max(COMBAT_BOT_PULSE_DIM, Math.min(1.2, pulse));
+
+      let model = mat4.translate(mat4.identity(), bot.x, 0, bot.y);
+      model = mat4.rotateY(model, heading);
+
+      this.renderer.drawMeshWithMatrix(
+        this.combatBotHandle,
+        model,
+        tint, tint, tint,
+        0, // no flash
+      );
+    }
+  }
+
+  /**
+   * Render all active visible salvage as rotating 3D diamonds.
+   * Applies damage flash and gentle pulsing tint.
+   */
+  renderSalvage(
+    entities: readonly GameEntity[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    for (let i = 0; i < entities.length; i++) {
+      const entity = entities[i];
+      if (entity.type !== 'salvage' || !entity.active || !entity.visible) continue;
+
+      const salvage = entity as Salvage;
+
+      // Visibility culling
+      const dx = salvage.x - playerX;
+      const dy = salvage.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      // Rotation: constant Y-axis spin
+      const rotY = time * SALVAGE_ROTATION_SPEED;
+
+      // Pulsing scale
+      const pulse = 1 + Math.sin(time * SALVAGE_PULSE_FREQ) * SALVAGE_PULSE_AMP;
+
+      // Damage flash
+      const flash = salvage.damageFlash > 0 ? Math.min(salvage.damageFlash, 1) : 0;
+
+      this.renderer.drawMeshTinted(
+        this.salvageHandle,
+        salvage.x,
+        salvage.y,
+        rotY,
+        pulse,
+        1, 1, 1, // white tint (mesh has amber color baked in)
+        flash,
+      );
+    }
+  }
+
+  /**
+   * Render all active projectiles as small 3D elongated shapes.
+   * Enemy projectiles, combat bot projectiles (from CombatSystem), and homing missiles
+   * all use the same mesh at different scales and tint colors.
+   */
+  renderProjectiles(
+    enemyProjectiles: readonly Projectile[],
+    combatBotProjectiles: readonly Projectile[],
+    homingMissiles: readonly Missile[],
+    playerX: number,
+    playerY: number,
+    viewRadius: number,
+    _time: number,
+  ): void {
+    const viewRadiusSq = viewRadius * viewRadius;
+
+    // Enemy projectiles — red tint, normal scale
+    for (let i = 0; i < enemyProjectiles.length; i++) {
+      const p = enemyProjectiles[i];
+      if (!p.active) continue;
+
+      const dx = p.x - playerX;
+      const dy = p.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      const heading = -Math.atan2(p.vx, p.vy);
+      let model = mat4.translate(mat4.identity(), p.x, 0, p.y);
+      model = mat4.rotateY(model, heading);
+      model = mat4.scale(model, ENEMY_PROJ_SCALE, ENEMY_PROJ_SCALE, ENEMY_PROJ_SCALE);
+
+      this.renderer.drawMeshWithMatrix(
+        this.projectileHandle,
+        model,
+        1.2, 0.4, 0.3, // red tint
+        0,
+      );
+    }
+
+    // Combat bot projectiles — blue tint, tiny scale
+    for (let i = 0; i < combatBotProjectiles.length; i++) {
+      const p = combatBotProjectiles[i];
+      if (!p.active) continue;
+
+      const dx = p.x - playerX;
+      const dy = p.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      const heading = -Math.atan2(p.vx, p.vy);
+      let model = mat4.translate(mat4.identity(), p.x, 0, p.y);
+      model = mat4.rotateY(model, heading);
+      model = mat4.scale(model, COMBAT_BOT_PROJ_SCALE, COMBAT_BOT_PROJ_SCALE, COMBAT_BOT_PROJ_SCALE);
+
+      this.renderer.drawMeshWithMatrix(
+        this.projectileHandle,
+        model,
+        0.4, 0.6, 1.2, // blue tint
+        0,
+      );
+    }
+
+    // Homing missiles — orange tint, larger scale
+    for (let i = 0; i < homingMissiles.length; i++) {
+      const m = homingMissiles[i];
+      if (!m.active) continue;
+
+      const dx = m.x - playerX;
+      const dy = m.y - playerY;
+      if (dx * dx + dy * dy > viewRadiusSq) continue;
+
+      const heading = -Math.atan2(m.vx, m.vy);
+      let model = mat4.translate(mat4.identity(), m.x, 0, m.y);
+      model = mat4.rotateY(model, heading);
+      model = mat4.scale(model, HOMING_MISSILE_SCALE, HOMING_MISSILE_SCALE, HOMING_MISSILE_SCALE);
+
+      this.renderer.drawMeshWithMatrix(
+        this.projectileHandle,
+        model,
+        1.3, 0.7, 0.2, // orange tint
+        0,
+      );
+    }
+  }
+
   /** Clean up all GPU resources */
   dispose(): void {
     const sizes = ['small', 'medium', 'large'] as const;
@@ -377,5 +643,9 @@ export class EntityRenderer3D {
     this.renderer.deleteMesh(this.bruteHandle);
     this.renderer.deleteMesh(this.rangedHandle);
     this.renderer.deleteMesh(this.bossHandle);
+    this.renderer.deleteMesh(this.miningBotHandle);
+    this.renderer.deleteMesh(this.combatBotHandle);
+    this.renderer.deleteMesh(this.salvageHandle);
+    this.renderer.deleteMesh(this.projectileHandle);
   }
 }


### PR DESCRIPTION
## Summary

Extends the 3D rendering pipeline to cover all remaining world-space entity types: mining bots, combat bots, salvage, and projectiles. Also reduces BlipRenderer to ghost-blips and labels only, since entity shapes are now handled by the 3D renderer.

## Changes

The implementation walks through three connected changes:

**1. New 3D render methods in EntityRenderer3D** (`prd-001`)
- `renderMiningBots()` renders active mining bots as 3D icospheres with time-based spinning when mining, and heading-based rotation when deploying
- `renderCombatBots()` renders combat bots as 3D chevrons facing their movement direction, with a lifetime-based pulsing tint that dims as the bot approaches expiry
- `renderSalvage()` renders salvage (both towed and untowed) as rotating 3D diamonds with pulsing scale and damage flash support
- `renderProjectiles()` renders three projectile types using a shared mesh at different scales and tint colors: red for enemy projectiles, blue for combat bot shots, orange for homing missiles
- All four mesh handles are pre-generated in the constructor and cleaned up in `dispose()`
- All methods implement squared-distance visibility culling

**2. main.ts integration** (`prd-001`)
- Added calls to all four new render methods in the 3D render block, between enemies and player rendering
- Wired up the correct data sources: `miningBotSystem.getBots()`, `combatBotSystem.bots`, `combatSystem.projectiles`, `combatBotSystem.botProjectiles`, `abilitySystem.missiles`

**3. BlipRenderer cleanup** (`prd-003`)
- Removed asteroid shape rendering (irregular polygon, glow, damage flash)
- Removed salvage shape rendering (pulsing diamond, aura, damage flash)
- Preserved ghost blip rendering for invisible enemies with last-known positions
- Preserved resolution labels (S/M/L, S/B/R/BOSS, etc.)
- Resource blips remain as 2D circles (no 3D mesh yet)

## Test Coverage

- 21 new behavioral tests covering all new render methods
- Tests verify culling, animation, lifetime pulse, damage flash, tint colors, and inactive entity skipping
- Updated constructor and dispose tests to reflect new mesh handle counts (36 -> 40)
- Full suite: 638 tests passing

## Quality Gates

- TypeScript strict mode: pass
- Vite production build: pass
- All 638 tests: pass

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2