### PR TITLE
3D lighting polish: Blinn-Phong specular, emissive glow, theme colors

### DIFF
--- a/src/rendering/EntityRenderer3D.test.ts
+++ b/src/rendering/EntityRenderer3D.test.ts
@@ -23,6 +23,10 @@ function createMockRenderer() {
     tintG: number;
     tintB: number;
     flash: number;
+    specular: number;
+    emissiveR: number;
+    emissiveG: number;
+    emissiveB: number;
   }[] = [];
 
   const drawMeshWithMatrixCalls: {
@@ -32,6 +36,10 @@ function createMockRenderer() {
     tintG: number;
     tintB: number;
     flash: number;
+    specular: number;
+    emissiveR: number;
+    emissiveG: number;
+    emissiveB: number;
   }[] = [];
 
   const renderer = {
@@ -47,13 +55,13 @@ function createMockRenderer() {
       } as unknown as MeshHandle;
     }),
     drawMeshTinted: vi.fn(
-      (handle: MeshHandle, worldX: number, worldY: number, rotationY: number, scale: number, tintR: number, tintG: number, tintB: number, flash: number) => {
-        drawMeshTintedCalls.push({ handle, worldX, worldY, rotationY, scale, tintR, tintG, tintB, flash });
+      (handle: MeshHandle, worldX: number, worldY: number, rotationY: number, scale: number, tintR: number, tintG: number, tintB: number, flash: number, specular = 0, emissiveR = 0, emissiveG = 0, emissiveB = 0) => {
+        drawMeshTintedCalls.push({ handle, worldX, worldY, rotationY, scale, tintR, tintG, tintB, flash, specular, emissiveR, emissiveG, emissiveB });
       },
     ),
     drawMeshWithMatrix: vi.fn(
-      (handle: MeshHandle, modelMatrix: Float32Array, tintR: number, tintG: number, tintB: number, flash: number) => {
-        drawMeshWithMatrixCalls.push({ handle, modelMatrix, tintR, tintG, tintB, flash });
+      (handle: MeshHandle, modelMatrix: Float32Array, tintR: number, tintG: number, tintB: number, flash: number, specular = 0, emissiveR = 0, emissiveG = 0, emissiveB = 0) => {
+        drawMeshWithMatrixCalls.push({ handle, modelMatrix, tintR, tintG, tintB, flash, specular, emissiveR, emissiveG, emissiveB });
       },
     ),
     deleteMesh: vi.fn(),
@@ -864,6 +872,159 @@ describe('EntityRenderer3D', () => {
       );
 
       expect(drawMeshWithMatrixCalls.length).toBe(3);
+
+      entityRenderer.dispose();
+    });
+  });
+
+  describe('material properties', () => {
+    it('asteroids have zero specular (matte appearance)', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeAsteroid({ x: 10, y: 20, active: true }),
+      ];
+      entityRenderer.renderAsteroids(entities, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls[0].specular).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('player ship has metallic specular', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderPlayer(0, 0, 0, 0, 0);
+
+      expect(drawMeshWithMatrixCalls[0].specular).toBeGreaterThan(0.5);
+
+      entityRenderer.dispose();
+    });
+
+    it('mining bots have metallic specular', () => {
+      const { renderer, drawMeshTintedCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [{
+        x: 50, y: 60, vx: 0, vy: 0, angle: 0,
+        targetAsteroid: null, state: MiningBotState.Mining,
+        miningProgress: 0, miningRate: 1, lifetime: 30,
+        active: true, aggroTimer: 5, energyAccum: 0,
+        energyTextTimer: 0, slotIndex: 0,
+      }] as MiningBot[];
+      entityRenderer.renderMiningBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshTintedCalls[0].specular).toBeGreaterThan(0.5);
+
+      entityRenderer.dispose();
+    });
+
+    it('combat bots have metallic specular', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const bots = [{
+        x: 50, y: 60, vx: 1, vy: 0, angle: 0,
+        state: CombatBotState.SeekingEnemy, targetEnemy: null,
+        targetX: 100, targetY: 100,
+        health: 30, maxHealth: 30, damage: 4,
+        fireRate: 1.5, fireTimer: 0, range: 200,
+        lifetime: 20, maxLifetime: 20,
+        active: true, slotIndex: 0,
+      }] as CombatBot[];
+      entityRenderer.renderCombatBots(bots, 0, 0, 500, 1.0);
+
+      expect(drawMeshWithMatrixCalls[0].specular).toBeGreaterThan(0.5);
+
+      entityRenderer.dispose();
+    });
+
+    it('boss at phase 2 has non-zero emissive glow', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeBoss({ x: 10, y: 10, bossPhase: 2 }),
+      ];
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      // Phase 2 should have emissive > 0
+      expect(drawMeshWithMatrixCalls[0].emissiveR).toBeGreaterThan(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('boss at phase 3 has stronger emissive than phase 2', () => {
+      const { renderer: renderer2, drawMeshWithMatrixCalls: calls2 } = createMockRenderer();
+      const er2 = new EntityRenderer3D(renderer2);
+      er2.renderEnemies([makeBoss({ x: 10, y: 10, bossPhase: 2 })] as GameEntity[], 0, 0, 500, 0);
+      const phase2EmR = calls2[0].emissiveR;
+      er2.dispose();
+
+      const { renderer: renderer3, drawMeshWithMatrixCalls: calls3 } = createMockRenderer();
+      const er3 = new EntityRenderer3D(renderer3);
+      er3.renderEnemies([makeBoss({ x: 10, y: 10, bossPhase: 3 })] as GameEntity[], 0, 0, 500, 0);
+      const phase3EmR = calls3[0].emissiveR;
+      er3.dispose();
+
+      expect(phase3EmR).toBeGreaterThan(phase2EmR);
+    });
+
+    it('boss at phase 1 has zero emissive', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      const entities: GameEntity[] = [
+        makeBoss({ x: 10, y: 10, bossPhase: 1 }),
+      ];
+      entityRenderer.renderEnemies(entities, 0, 0, 500, 0);
+
+      expect(drawMeshWithMatrixCalls[0].emissiveR).toBe(0);
+      expect(drawMeshWithMatrixCalls[0].emissiveG).toBe(0);
+      expect(drawMeshWithMatrixCalls[0].emissiveB).toBe(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('enemy projectiles have non-zero emissive for bloom', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      entityRenderer.renderProjectiles(
+        [{ x: 50, y: 60, vx: 0, vy: -100, damage: 8, active: true, lifetime: 2 }],
+        [], [], 0, 0, 500, 0,
+      );
+
+      expect(drawMeshWithMatrixCalls[0].emissiveR).toBeGreaterThan(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('player has engine emissive when thrusting forward', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // Full thrust
+      entityRenderer.renderPlayer(0, 0, 0, 1, 0);
+
+      // Should have emissive > 0 when thrusting
+      expect(drawMeshWithMatrixCalls[0].emissiveG).toBeGreaterThan(0);
+
+      entityRenderer.dispose();
+    });
+
+    it('player has no engine emissive when not thrusting', () => {
+      const { renderer, drawMeshWithMatrixCalls } = createMockRenderer();
+      const entityRenderer = new EntityRenderer3D(renderer);
+
+      // No thrust
+      entityRenderer.renderPlayer(0, 0, 0, 0, 0);
+
+      expect(drawMeshWithMatrixCalls[0].emissiveR).toBe(0);
+      expect(drawMeshWithMatrixCalls[0].emissiveG).toBe(0);
+      expect(drawMeshWithMatrixCalls[0].emissiveB).toBe(0);
 
       entityRenderer.dispose();
     });

--- a/src/rendering/EntityRenderer3D.ts
+++ b/src/rendering/EntityRenderer3D.ts
@@ -9,11 +9,13 @@
  */
 
 import type { Renderer3D, MeshHandle } from './Renderer3D';
+import { parseHexColor } from './Renderer3D';
 import type { Asteroid, Enemy, GameEntity, HomeBase, Projectile, Salvage } from '../entities/Entity';
 import type { MiningBot } from '../systems/MiningBotSystem';
 import { MiningBotState } from '../systems/MiningBotSystem';
 import type { CombatBot } from '../systems/CombatBotSystem';
 import type { Missile } from '../systems/AbilitySystem';
+import { getTheme } from '../themes/theme';
 import { mat4 } from './math3d';
 import {
   createAsteroidMesh,
@@ -97,6 +99,81 @@ const COMBAT_BOT_PROJ_SCALE = 0.5;
 
 /** Homing missile scale (larger) */
 const HOMING_MISSILE_SCALE = 1.5;
+
+// ─── Material properties ──────────────────────────────────────────────────
+
+/** Specular intensity for metallic entities (player, bots) */
+const METALLIC_SPECULAR = 0.7;
+
+/** Specular intensity for home base */
+const HOME_BASE_SPECULAR = 0.3;
+
+/** Emissive intensity for scout enemies (subtle glow) */
+const SCOUT_EMISSIVE = 0.08;
+
+/** Emissive intensity for brute enemies */
+const BRUTE_EMISSIVE = 0.12;
+
+/** Emissive intensity for ranged enemies */
+const RANGED_EMISSIVE = 0.1;
+
+/** Boss emissive intensity at phase 2 */
+const BOSS_PHASE2_EMISSIVE = 0.2;
+
+/** Boss emissive intensity at phase 3 (base, before pulse) */
+const BOSS_PHASE3_EMISSIVE = 0.35;
+
+/** Boss emissive pulse amplitude at phase 3 */
+const BOSS_PHASE3_PULSE_AMP = 0.15;
+
+/** Boss emissive pulse frequency at phase 3 */
+const BOSS_PHASE3_PULSE_FREQ = 4;
+
+/** Salvage emissive glow (subtle amber) */
+const SALVAGE_EMISSIVE = 0.1;
+
+/** Projectile emissive intensity (bright, should trigger bloom) */
+const PROJECTILE_EMISSIVE = 0.4;
+
+// ─── Pre-allocated color cache for theme colors ──────────────────────────
+
+/** Cached parsed theme colors to avoid per-frame hex parsing.
+ *  Updated when theme name changes. */
+let cachedThemeName = '';
+const cachedColors = {
+  asteroid: [0, 0, 0] as [number, number, number],
+  enemyScout: [0, 0, 0] as [number, number, number],
+  enemyBrute: [0, 0, 0] as [number, number, number],
+  enemyRanged: [0, 0, 0] as [number, number, number],
+  enemyBoss: [0, 0, 0] as [number, number, number],
+  salvage: [0, 0, 0] as [number, number, number],
+  miningBot: [0, 0, 0] as [number, number, number],
+  combatBot: [0, 0, 0] as [number, number, number],
+  botProjectile: [0, 0, 0] as [number, number, number],
+  enemy: [0, 0, 0] as [number, number, number],
+};
+
+/** Refresh cached parsed colors if the theme has changed. No-alloc when unchanged. */
+function refreshThemeColors(): void {
+  const theme = getTheme();
+  if (theme.name === cachedThemeName) return;
+  cachedThemeName = theme.name;
+  const e = theme.entities;
+  const copy = (dst: [number, number, number], hex: string) => {
+    const [r, g, b] = parseHexColor(hex);
+    dst[0] = r; dst[1] = g; dst[2] = b;
+  };
+  copy(cachedColors.asteroid, e.asteroid);
+  copy(cachedColors.enemyScout, e.enemyScout);
+  copy(cachedColors.enemyBrute, e.enemyBrute);
+  copy(cachedColors.enemyRanged, e.enemyRanged);
+  copy(cachedColors.enemyBoss, e.enemyBoss);
+  copy(cachedColors.salvage, e.salvage);
+  copy(cachedColors.miningBot, e.miningBot);
+  copy(cachedColors.combatBot, e.combatBot);
+  copy(cachedColors.botProjectile, e.botProjectile);
+  copy(cachedColors.enemy, e.enemy);
+}
 
 // ─── Position hash for deterministic seeding ────────────────────────────
 
@@ -187,6 +264,7 @@ export class EntityRenderer3D {
     viewRadius: number,
     time: number,
   ): void {
+    refreshThemeColors();
     const viewRadiusSq = viewRadius * viewRadius;
 
     for (let i = 0; i < entities.length; i++) {
@@ -220,6 +298,7 @@ export class EntityRenderer3D {
       // Damage flash: override tint toward white
       const flash = asteroid.damageFlash > 0 ? Math.min(asteroid.damageFlash, 1) : 0;
 
+      // Asteroids are matte: zero specular, no emissive
       this.renderer.drawMeshTinted(
         handle,
         asteroid.x,
@@ -230,6 +309,7 @@ export class EntityRenderer3D {
         tintG,
         tintB,
         flash,
+        0, // matte - no specular
       );
     }
   }
@@ -261,6 +341,7 @@ export class EntityRenderer3D {
       tintG,
       tintB,
       0, // no flash
+      HOME_BASE_SPECULAR,
     );
   }
 
@@ -299,6 +380,9 @@ export class EntityRenderer3D {
     const tintG = 1 + glow;
     const tintB = 1 + glow * 0.8;
 
+    // Engine emissive: subtle glow when thrusting, visible even in shadow
+    const emissiveStr = thrustAmount * 0.15;
+
     this.renderer.drawMeshWithMatrix(
       this.playerHandle,
       model,
@@ -306,6 +390,10 @@ export class EntityRenderer3D {
       Math.min(tintG, 1.5),
       Math.min(tintB, 1.5),
       0, // no flash
+      METALLIC_SPECULAR,
+      emissiveStr * 0.3,  // warm R
+      emissiveStr,         // green (engine color)
+      emissiveStr * 0.8,   // cyan-ish B
     );
   }
 
@@ -360,6 +448,7 @@ export class EntityRenderer3D {
   }
 
   private renderScout(enemy: Enemy, heading: number, time: number): void {
+    refreshThemeColors();
     let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
     model = mat4.rotateY(model, heading);
 
@@ -367,27 +456,45 @@ export class EntityRenderer3D {
     const wobble = Math.sin(time * SCOUT_WOBBLE_FREQ) * SCOUT_WOBBLE_AMP;
     model = mat4.rotateZ(model, wobble);
 
-    this.renderer.drawMeshWithMatrix(this.scoutHandle, model, 1, 1, 1, 0);
+    const c = cachedColors.enemyScout;
+    this.renderer.drawMeshWithMatrix(
+      this.scoutHandle, model, 1, 1, 1, 0,
+      0, // no specular (organic enemy)
+      c[0] * SCOUT_EMISSIVE, c[1] * SCOUT_EMISSIVE, c[2] * SCOUT_EMISSIVE,
+    );
   }
 
   private renderBrute(enemy: Enemy, heading: number, time: number): void {
+    refreshThemeColors();
     let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
     // Face movement direction + slow constant rotation
     model = mat4.rotateY(model, heading + time * BRUTE_ROTATION_SPEED);
 
-    this.renderer.drawMeshWithMatrix(this.bruteHandle, model, 1, 1, 1, 0);
+    const c = cachedColors.enemyBrute;
+    this.renderer.drawMeshWithMatrix(
+      this.bruteHandle, model, 1, 1, 1, 0,
+      0,
+      c[0] * BRUTE_EMISSIVE, c[1] * BRUTE_EMISSIVE, c[2] * BRUTE_EMISSIVE,
+    );
   }
 
   private renderRanged(enemy: Enemy, heading: number, time: number): void {
+    refreshThemeColors();
     // Gentle bobbing: translate Y up/down
     const bob = Math.sin(time * RANGED_BOB_FREQ) * RANGED_BOB_AMP;
     let model = mat4.translate(mat4.identity(), enemy.x, bob, enemy.y);
     model = mat4.rotateY(model, heading);
 
-    this.renderer.drawMeshWithMatrix(this.rangedHandle, model, 1, 1, 1, 0);
+    const c = cachedColors.enemyRanged;
+    this.renderer.drawMeshWithMatrix(
+      this.rangedHandle, model, 1, 1, 1, 0,
+      0,
+      c[0] * RANGED_EMISSIVE, c[1] * RANGED_EMISSIVE, c[2] * RANGED_EMISSIVE,
+    );
   }
 
   private renderBoss(enemy: Enemy, heading: number, time: number): void {
+    refreshThemeColors();
     // Pulsing scale
     const pulse = 1 + Math.sin(time * BOSS_PULSE_FREQ) * BOSS_PULSE_AMP;
     let model = mat4.translate(mat4.identity(), enemy.x, 0, enemy.y);
@@ -401,17 +508,37 @@ export class EntityRenderer3D {
     let tintR = 1;
     let tintG = 1;
     let tintB = 1;
+
+    // Phase-based emissive glow
+    let emR = 0;
+    let emG = 0;
+    let emB = 0;
+    const c = cachedColors.enemyBoss;
+
     if (enemy.bossPhase >= 3) {
       tintR = 1.3;
       tintG = 0.5;
       tintB = 0.4;
+      // Phase 3: red pulsing emissive
+      const emPulse = BOSS_PHASE3_EMISSIVE + Math.sin(time * BOSS_PHASE3_PULSE_FREQ) * BOSS_PHASE3_PULSE_AMP;
+      emR = c[0] * emPulse;
+      emG = c[1] * emPulse * 0.5; // suppress green for redder glow
+      emB = c[2] * emPulse * 0.3;
     } else if (enemy.bossPhase >= 2) {
       tintR = 1.2;
       tintG = 0.8;
       tintB = 0.5;
+      // Phase 2: steady orange emissive
+      emR = c[0] * BOSS_PHASE2_EMISSIVE;
+      emG = c[1] * BOSS_PHASE2_EMISSIVE * 0.7;
+      emB = c[2] * BOSS_PHASE2_EMISSIVE * 0.3;
     }
 
-    this.renderer.drawMeshWithMatrix(this.bossHandle, model, tintR, tintG, tintB, 0);
+    this.renderer.drawMeshWithMatrix(
+      this.bossHandle, model, tintR, tintG, tintB, 0,
+      0, // no specular (boss is organic/magical)
+      emR, emG, emB,
+    );
   }
 
   /**
@@ -450,6 +577,7 @@ export class EntityRenderer3D {
         1,
         1, 1, 1, // white tint (no tint)
         0, // no flash
+        METALLIC_SPECULAR, // metallic bot
       );
     }
   }
@@ -497,6 +625,7 @@ export class EntityRenderer3D {
         model,
         tint, tint, tint,
         0, // no flash
+        METALLIC_SPECULAR, // metallic bot
       );
     }
   }
@@ -512,7 +641,9 @@ export class EntityRenderer3D {
     viewRadius: number,
     time: number,
   ): void {
+    refreshThemeColors();
     const viewRadiusSq = viewRadius * viewRadius;
+    const sc = cachedColors.salvage;
 
     for (let i = 0; i < entities.length; i++) {
       const entity = entities[i];
@@ -542,6 +673,8 @@ export class EntityRenderer3D {
         pulse,
         1, 1, 1, // white tint (mesh has amber color baked in)
         flash,
+        0, // no specular
+        sc[0] * SALVAGE_EMISSIVE, sc[1] * SALVAGE_EMISSIVE, sc[2] * SALVAGE_EMISSIVE,
       );
     }
   }
@@ -561,8 +694,9 @@ export class EntityRenderer3D {
     _time: number,
   ): void {
     const viewRadiusSq = viewRadius * viewRadius;
+    const pe = PROJECTILE_EMISSIVE;
 
-    // Enemy projectiles — red tint, normal scale
+    // Enemy projectiles — red tint, normal scale, red emissive
     for (let i = 0; i < enemyProjectiles.length; i++) {
       const p = enemyProjectiles[i];
       if (!p.active) continue;
@@ -581,10 +715,12 @@ export class EntityRenderer3D {
         model,
         1.2, 0.4, 0.3, // red tint
         0,
+        0, // no specular
+        pe, pe * 0.3, pe * 0.2, // red emissive for bloom
       );
     }
 
-    // Combat bot projectiles — blue tint, tiny scale
+    // Combat bot projectiles — blue tint, tiny scale, blue emissive
     for (let i = 0; i < combatBotProjectiles.length; i++) {
       const p = combatBotProjectiles[i];
       if (!p.active) continue;
@@ -603,10 +739,12 @@ export class EntityRenderer3D {
         model,
         0.4, 0.6, 1.2, // blue tint
         0,
+        0,
+        pe * 0.2, pe * 0.4, pe, // blue emissive for bloom
       );
     }
 
-    // Homing missiles — orange tint, larger scale
+    // Homing missiles — orange tint, larger scale, orange emissive
     for (let i = 0; i < homingMissiles.length; i++) {
       const m = homingMissiles[i];
       if (!m.active) continue;
@@ -625,6 +763,8 @@ export class EntityRenderer3D {
         model,
         1.3, 0.7, 0.2, // orange tint
         0,
+        0,
+        pe, pe * 0.5, pe * 0.1, // orange emissive for bloom
       );
     }
   }

--- a/src/rendering/Renderer3D.test.ts
+++ b/src/rendering/Renderer3D.test.ts
@@ -145,23 +145,29 @@ describe('Renderer3D', () => {
 
         renderer.drawMeshTinted(mesh, 10, 20, 0, 1, 0.8, 0.2, 0.1, 0.5);
 
-        // Should have set tint color, then reset it (2 calls)
+        // Should have set tint + emissive, then reset both (4 uniform3fv calls)
         const uniform3fvCalls = (gl.uniform3fv as ReturnType<typeof vi.fn>).mock.calls;
-        expect(uniform3fvCalls.length).toBe(2);
+        expect(uniform3fvCalls.length).toBe(4);
         // First call: set tint (Float32Array)
         expect(Array.from(uniform3fvCalls[0][1])).toEqual([
           expect.closeTo(0.8, 4),
           expect.closeTo(0.2, 4),
           expect.closeTo(0.1, 4),
         ]);
-        // Second call: reset to white (Float32Array)
-        expect(Array.from(uniform3fvCalls[1][1])).toEqual([1, 1, 1]);
+        // Second call: set emissive (defaults to black)
+        expect(Array.from(uniform3fvCalls[1][1])).toEqual([0, 0, 0]);
+        // Third call: reset tint to white
+        expect(Array.from(uniform3fvCalls[2][1])).toEqual([1, 1, 1]);
+        // Fourth call: reset emissive to black
+        expect(Array.from(uniform3fvCalls[3][1])).toEqual([0, 0, 0]);
 
-        // Should have set flash, then reset it (2 calls)
+        // Should have set flash + specular, then reset both (4 uniform1f calls)
         const uniform1fCalls = (gl.uniform1f as ReturnType<typeof vi.fn>).mock.calls;
-        expect(uniform1fCalls.length).toBe(2);
-        expect(uniform1fCalls[0][1]).toBe(0.5);
-        expect(uniform1fCalls[1][1]).toBe(0);
+        expect(uniform1fCalls.length).toBe(4);
+        expect(uniform1fCalls[0][1]).toBe(0.5);  // flash set
+        expect(uniform1fCalls[1][1]).toBe(0);     // specular set (default 0)
+        expect(uniform1fCalls[2][1]).toBe(0);     // flash reset
+        expect(uniform1fCalls[3][1]).toBe(0);     // specular reset
       });
     });
   });

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -38,7 +38,7 @@ uniform vec3 uTintColor;
 uniform float uDamageFlash;
 uniform float uSpecular;   // 0 = matte, 1 = full specular shine
 uniform vec3 uEmissive;    // additive glow color (independent of lighting)
-uniform vec3 uViewDir;     // camera look direction (set once per frame)
+uniform vec3 uViewDir;     // direction from scene toward camera (set once per frame)
 
 out vec4 fragColor;
 
@@ -351,10 +351,11 @@ export class Renderer3D {
     this.viewMatrix = mat4.lookAt(eye, target, up);
     gl.uniformMatrix4fv(this.uView, false, this.viewMatrix);
 
-    // Compute and set view direction (eye -> target, normalized) for specular
-    const vdx = target[0] - eye[0];
-    const vdy = target[1] - eye[1];
-    const vdz = target[2] - eye[2];
+    // Compute view direction (target -> eye, normalized) for Blinn-Phong specular.
+    // In Blinn-Phong, V points from fragment toward the camera.
+    const vdx = eye[0] - target[0];
+    const vdy = eye[1] - target[1];
+    const vdz = eye[2] - target[2];
     const vdLen = Math.sqrt(vdx * vdx + vdy * vdy + vdz * vdz);
     if (vdLen > 0) {
       this.viewDirArray[0] = vdx / vdLen;

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -36,13 +36,31 @@ uniform vec3 uLightDir;
 uniform vec3 uAmbient;
 uniform vec3 uTintColor;
 uniform float uDamageFlash;
+uniform float uSpecular;   // 0 = matte, 1 = full specular shine
+uniform vec3 uEmissive;    // additive glow color (independent of lighting)
+uniform vec3 uViewDir;     // camera look direction (set once per frame)
 
 out vec4 fragColor;
 
 void main() {
   vec3 normal = normalize(vNormal);
-  float diffuse = max(dot(normal, uLightDir), 0.0);
-  vec3 lit = vColor * uTintColor * (uAmbient + vec3(diffuse));
+
+  // Diffuse (Lambertian)
+  float NdotL = max(dot(normal, uLightDir), 0.0);
+
+  // Blinn-Phong specular: half-vector between light and view
+  vec3 halfDir = normalize(uLightDir + uViewDir);
+  float NdotH = max(dot(normal, halfDir), 0.0);
+  // Shininess exponent 32 gives a tight specular highlight, good for metallic surfaces
+  float spec = uSpecular * pow(NdotH, 32.0) * NdotL; // spec only where lit
+
+  // Combine: ambient + diffuse + specular, then multiply by base color and tint
+  vec3 lighting = uAmbient + vec3(NdotL) + vec3(spec * 0.6);
+  vec3 lit = vColor * uTintColor * lighting;
+
+  // Add emissive glow (not affected by lighting — always visible)
+  lit += uEmissive;
+
   // Damage flash: mix toward white
   vec3 finalColor = mix(lit, vec3(1.0), uDamageFlash);
   fragColor = vec4(finalColor, 1.0);
@@ -98,8 +116,8 @@ const ORTHO_HALF_SIZE = 400;
 
 // ─── Light direction (above-right, normalized) ──────────────────────────
 
-const LIGHT_DIR: Vec3 = vec3.normalize([0.4, 1.0, 0.3]);
-const AMBIENT: Vec3 = [0.3, 0.3, 0.3];
+const LIGHT_DIR: Vec3 = vec3.normalize([0.3, 0.9, 0.4]);
+const AMBIENT: Vec3 = [0.25, 0.25, 0.28]; // slightly blue-tinted ambient for depth
 
 // ─── Renderer class ─────────────────────────────────────────────────────
 
@@ -116,6 +134,9 @@ export class Renderer3D {
   private uAmbient: WebGLUniformLocation | null;
   private uTintColor: WebGLUniformLocation | null;
   private uDamageFlash: WebGLUniformLocation | null;
+  private uSpecular: WebGLUniformLocation | null;
+  private uEmissive: WebGLUniformLocation | null;
+  private uViewDir: WebGLUniformLocation | null;
 
   // Clear color (defaults to transparent black)
   private clearR = 0;
@@ -126,6 +147,11 @@ export class Renderer3D {
   // Pre-allocated arrays for tint uniforms (avoid per-frame allocation)
   private tintArray = new Float32Array([1, 1, 1]);
   private defaultTint = new Float32Array([1, 1, 1]);
+
+  // Pre-allocated arrays for material uniforms (avoid per-frame allocation)
+  private emissiveArray = new Float32Array([0, 0, 0]);
+  private defaultEmissive = new Float32Array([0, 0, 0]);
+  private viewDirArray = new Float32Array([0, 1, 0]);
 
   // Current camera matrices (reused each frame)
   private projectionMatrix: Float32Array = mat4.identity();
@@ -144,6 +170,9 @@ export class Renderer3D {
     this.uAmbient = gl.getUniformLocation(program, 'uAmbient');
     this.uTintColor = gl.getUniformLocation(program, 'uTintColor');
     this.uDamageFlash = gl.getUniformLocation(program, 'uDamageFlash');
+    this.uSpecular = gl.getUniformLocation(program, 'uSpecular');
+    this.uEmissive = gl.getUniformLocation(program, 'uEmissive');
+    this.uViewDir = gl.getUniformLocation(program, 'uViewDir');
 
     // Set static uniforms
     gl.uniform3fv(this.uLightDir, LIGHT_DIR);
@@ -152,6 +181,11 @@ export class Renderer3D {
     // Set default tint (white = no tint) and no flash
     gl.uniform3fv(this.uTintColor, this.defaultTint);
     gl.uniform1f(this.uDamageFlash, 0);
+
+    // Set default material: matte (no specular), no emissive glow
+    gl.uniform1f(this.uSpecular, 0);
+    gl.uniform3fv(this.uEmissive, this.defaultEmissive);
+    gl.uniform3fv(this.uViewDir, this.viewDirArray);
 
     // Enable depth testing
     gl.enable(gl.DEPTH_TEST);
@@ -316,6 +350,18 @@ export class Renderer3D {
 
     this.viewMatrix = mat4.lookAt(eye, target, up);
     gl.uniformMatrix4fv(this.uView, false, this.viewMatrix);
+
+    // Compute and set view direction (eye -> target, normalized) for specular
+    const vdx = target[0] - eye[0];
+    const vdy = target[1] - eye[1];
+    const vdz = target[2] - eye[2];
+    const vdLen = Math.sqrt(vdx * vdx + vdy * vdy + vdz * vdz);
+    if (vdLen > 0) {
+      this.viewDirArray[0] = vdx / vdLen;
+      this.viewDirArray[1] = vdy / vdLen;
+      this.viewDirArray[2] = vdz / vdLen;
+    }
+    gl.uniform3fv(this.uViewDir, this.viewDirArray);
   }
 
   /**
@@ -345,7 +391,7 @@ export class Renderer3D {
   }
 
   /**
-   * Draw a mesh with tint color and damage flash.
+   * Draw a mesh with tint color, damage flash, and material properties.
    * @param handle Mesh handle from uploadMesh
    * @param worldX World X position
    * @param worldY World Y position (maps to 3D Z)
@@ -355,6 +401,10 @@ export class Renderer3D {
    * @param tintG Tint color green component (0-1, default 1)
    * @param tintB Tint color blue component (0-1, default 1)
    * @param flash Damage flash intensity (0 = none, 1 = full white)
+   * @param specular Specular intensity (0 = matte, 1 = full shine, default 0)
+   * @param emissiveR Emissive glow red (0-1, default 0)
+   * @param emissiveG Emissive glow green (0-1, default 0)
+   * @param emissiveB Emissive glow blue (0-1, default 0)
    */
   drawMeshTinted(
     handle: MeshHandle,
@@ -366,6 +416,10 @@ export class Renderer3D {
     tintG: number,
     tintB: number,
     flash: number,
+    specular = 0,
+    emissiveR = 0,
+    emissiveG = 0,
+    emissiveB = 0,
   ): void {
     const { gl } = this;
     this.tintArray[0] = tintR;
@@ -373,14 +427,21 @@ export class Renderer3D {
     this.tintArray[2] = tintB;
     gl.uniform3fv(this.uTintColor, this.tintArray);
     gl.uniform1f(this.uDamageFlash, flash);
+    gl.uniform1f(this.uSpecular, specular);
+    this.emissiveArray[0] = emissiveR;
+    this.emissiveArray[1] = emissiveG;
+    this.emissiveArray[2] = emissiveB;
+    gl.uniform3fv(this.uEmissive, this.emissiveArray);
     this.drawMesh(handle, worldX, worldY, rotationY, scaleVal);
     // Reset to defaults so subsequent drawMesh calls are unaffected
     gl.uniform3fv(this.uTintColor, this.defaultTint);
     gl.uniform1f(this.uDamageFlash, 0);
+    gl.uniform1f(this.uSpecular, 0);
+    gl.uniform3fv(this.uEmissive, this.defaultEmissive);
   }
 
   /**
-   * Draw a mesh with a pre-built model matrix, tint color, and damage flash.
+   * Draw a mesh with a pre-built model matrix, tint color, damage flash, and material properties.
    * Use this when you need arbitrary transforms (banking, bobbing) that
    * drawMesh/drawMeshTinted cannot express.
    */
@@ -391,6 +452,10 @@ export class Renderer3D {
     tintG: number,
     tintB: number,
     flash: number,
+    specular = 0,
+    emissiveR = 0,
+    emissiveG = 0,
+    emissiveB = 0,
   ): void {
     const { gl } = this;
     this.tintArray[0] = tintR;
@@ -398,12 +463,19 @@ export class Renderer3D {
     this.tintArray[2] = tintB;
     gl.uniform3fv(this.uTintColor, this.tintArray);
     gl.uniform1f(this.uDamageFlash, flash);
+    gl.uniform1f(this.uSpecular, specular);
+    this.emissiveArray[0] = emissiveR;
+    this.emissiveArray[1] = emissiveG;
+    this.emissiveArray[2] = emissiveB;
+    gl.uniform3fv(this.uEmissive, this.emissiveArray);
     gl.uniformMatrix4fv(this.uModel, false, modelMatrix);
     gl.bindVertexArray(handle.vao);
     gl.drawElements(gl.TRIANGLES, handle.indexCount, gl.UNSIGNED_SHORT, 0);
     // Reset to defaults
     gl.uniform3fv(this.uTintColor, this.defaultTint);
     gl.uniform1f(this.uDamageFlash, 0);
+    gl.uniform1f(this.uSpecular, 0);
+    gl.uniform3fv(this.uEmissive, this.defaultEmissive);
   }
 
   /** End the frame. Currently a no-op but reserved for future use. */

--- a/src/rendering/Renderer3D.ts
+++ b/src/rendering/Renderer3D.ts
@@ -90,7 +90,7 @@ export interface MeshHandle {
 // ─── Hex color parsing ──────────────────────────────────────────────────
 
 /** Parse a hex color string (#rgb, #rrggbb) into [r, g, b] floats 0-1 */
-function parseHexColor(hex: string): [number, number, number] {
+export function parseHexColor(hex: string): [number, number, number] {
   const h = hex.replace('#', '');
   let r: number, g: number, b: number;
   if (h.length === 3) {


### PR DESCRIPTION
## Summary

Enhances the 3D rendering pipeline with Blinn-Phong specular highlights, per-entity emissive glow, and theme-driven entity colors. Entities now have material properties — metallic surfaces (player, bots) reflect light with specular highlights, asteroids are matte, enemies glow with theme-colored emissive, and the boss has phase-dependent visual escalation (orange glow at phase 2, pulsing red at phase 3). Projectiles emit bright light that triggers the bloom post-processing effect.

## Changes

The work starts in `Renderer3D.ts` where the fragment shader is enhanced from simple diffuse-only lighting to a full ambient + Lambertian diffuse + Blinn-Phong specular + emissive model. Three new uniforms (`uSpecular`, `uEmissive`, `uViewDir`) are added with pre-allocated `Float32Array` buffers to avoid GC pressure. The `drawMeshTinted` and `drawMeshWithMatrix` methods gain optional `specular` and `emissive` parameters with backward-compatible defaults (zero specular, black emissive), so all existing call sites work unchanged.

`EntityRenderer3D.ts` then uses these new material parameters to give each entity type a distinct visual character. A theme color cache (`refreshThemeColors`) parses hex colors from the current theme only when the theme changes — zero allocation on typical frames. Enemy render methods now read theme colors and apply emissive glow scaled by subtype constants. The boss phase system is extended with emissive intensity that ramps from zero (phase 1) through steady orange (phase 2) to pulsing red (phase 3).

The existing test mock is updated to capture the new `specular` and `emissive` parameters, and 10 new tests verify material properties: matte asteroids, metallic player/bots, boss emissive progression, projectile bloom-readiness, and engine glow behavior.

A review pass caught that the Blinn-Phong view direction was initially pointing the wrong way (eye-to-target instead of target-to-eye) — fixed in a separate commit.

## PRDs Completed
1. **prd-001**: Enhanced lighting shader with Blinn-Phong specular and emissive support
2. **prd-002**: Theme-driven entity materials and enemy glow effects
3. **prd-003**: Post-processing integration verification and performance audit

## Test Coverage
- 648 tests pass across 40 files (10 new material property tests added)
- TypeScript strict mode: zero errors
- Production build: succeeds (134 KB gzipped)

## Quality Gates
- [x] All tests pass
- [x] TypeScript check passes
- [x] Build succeeds
- [x] No allocations in render hot path (theme colors cached, Float32Arrays pre-allocated)
- [x] Bloom works with emissive surfaces (emissive 0.4 exceeds 0.3 threshold)
- [x] Damage distortion applies to combined 3D+2D output (canvas layering unchanged)

Generated with [Claude Code](https://claude.com/claude-code) via /autopilot v2